### PR TITLE
perf: add React.cache auth dedup, Suspense streaming, and skeleton UIs

### DIFF
--- a/app/(dashboard)/documents/[id]/loading.tsx
+++ b/app/(dashboard)/documents/[id]/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function DocumentDetailLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-10 w-10 rounded-md" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-9 w-16" />
+      </div>
+      <div className="rounded-lg border">
+        <div className="border-b px-4 py-3">
+          <Skeleton className="h-5 w-24" />
+        </div>
+        <div className="space-y-2 p-4">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/documents/[id]/page.tsx
+++ b/app/(dashboard)/documents/[id]/page.tsx
@@ -1,31 +1,27 @@
+import { Suspense } from "react"
 import { notFound, redirect } from "next/navigation"
 import Link from "next/link"
 import { ArrowLeft } from "lucide-react"
 
-import { createClient } from "@/lib/supabase/server"
+import { getAuthUser } from "@/lib/supabase/user"
 import { getDocument } from "@/lib/documents/service"
 import { DOCUMENT_TYPE_LABELS } from "@/lib/validations/document"
 import { formatFileSize } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { Skeleton } from "@/components/ui/skeleton"
 import { DeleteButton } from "@/components/documents/delete-button"
 import type { DocumentType } from "@/lib/validations/document"
 
-export default async function DocumentDetailPage({
-  params,
+async function DocumentContent({
+  id,
+  userId,
 }: {
-  params: Promise<{ id: string }>
+  id: string
+  userId: string
 }) {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) redirect("/login")
-
-  const { id } = await params
-  const document = await getDocument(id, user.id)
+  const document = await getDocument(id, userId)
 
   if (!document) notFound()
 
@@ -73,5 +69,48 @@ export default async function DocumentDetailPage({
         </ScrollArea>
       </div>
     </div>
+  )
+}
+
+function DocumentDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-10 w-10 rounded-md" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-9 w-16" />
+      </div>
+      <div className="rounded-lg border">
+        <div className="border-b px-4 py-3">
+          <Skeleton className="h-5 w-24" />
+        </div>
+        <div className="space-y-2 p-4">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default async function DocumentDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const [user, { id }] = await Promise.all([getAuthUser(), params])
+
+  if (!user) redirect("/login")
+
+  return (
+    <Suspense fallback={<DocumentDetailSkeleton />}>
+      <DocumentContent id={id} userId={user.id} />
+    </Suspense>
   )
 }

--- a/app/(dashboard)/documents/loading.tsx
+++ b/app/(dashboard)/documents/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { DocumentListSkeleton } from "@/components/documents/document-list-skeleton"
+
+export default function DocumentsLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="h-5 w-56" />
+        </div>
+        <Skeleton className="h-10 w-24" />
+      </div>
+      <DocumentListSkeleton />
+    </div>
+  )
+}

--- a/app/(dashboard)/documents/page.tsx
+++ b/app/(dashboard)/documents/page.tsx
@@ -1,24 +1,27 @@
+import { Suspense } from "react"
 import { redirect } from "next/navigation"
-import { createClient } from "@/lib/supabase/server"
+import { getAuthUser } from "@/lib/supabase/user"
 import { listDocuments } from "@/lib/documents/service"
 import { DocumentList } from "@/components/documents/document-list"
 import { UploadDialog } from "@/components/documents/upload-dialog"
+import { DocumentListSkeleton } from "@/components/documents/document-list-skeleton"
 
-export default async function DocumentsPage() {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) redirect("/login")
-
-  const documents = await listDocuments(user.id)
+async function DocumentListSection({ userId }: { userId: string }) {
+  const documents = await listDocuments(userId)
 
   // Date를 직렬화 가능한 형태로 변환
   const serialized = documents.map((doc) => ({
     ...doc,
     createdAt: doc.createdAt.toISOString(),
   }))
+
+  return <DocumentList documents={serialized} />
+}
+
+export default async function DocumentsPage() {
+  const user = await getAuthUser()
+
+  if (!user) redirect("/login")
 
   return (
     <div className="space-y-6">
@@ -32,7 +35,9 @@ export default async function DocumentsPage() {
         <UploadDialog />
       </div>
 
-      <DocumentList documents={serialized} />
+      <Suspense fallback={<DocumentListSkeleton />}>
+        <DocumentListSection userId={user.id} />
+      </Suspense>
     </div>
   )
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation"
-import { createClient } from "@/lib/supabase/server"
-import { extractUserInfo } from "@/lib/supabase/user"
+import { getAuthUser, extractUserInfo } from "@/lib/supabase/user"
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar"
 import { AppSidebar } from "@/components/layout/app-sidebar"
 import { Topbar } from "@/components/layout/topbar"
@@ -10,10 +9,7 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const user = await getAuthUser()
 
   if (!user) {
     redirect("/login")

--- a/components/documents/document-list-skeleton.tsx
+++ b/components/documents/document-list-skeleton.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+function CardSkeleton() {
+  return (
+    <div className="rounded-xl border p-6 space-y-3">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-5" />
+          <Skeleton className="h-5 w-32" />
+        </div>
+        <Skeleton className="h-5 w-12 rounded-full" />
+      </div>
+      <Skeleton className="h-4 w-48" />
+    </div>
+  )
+}
+
+export function DocumentListSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }, (_, i) => (
+        <CardSkeleton key={i} />
+      ))}
+    </div>
+  )
+}

--- a/lib/supabase/user.ts
+++ b/lib/supabase/user.ts
@@ -1,4 +1,6 @@
+import { cache } from "react"
 import type { User } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase/server"
 
 export interface UserInfo {
   name: string | null
@@ -15,3 +17,12 @@ export function extractUserInfo(user: User): UserInfo {
       user.user_metadata?.avatar_url ?? user.user_metadata?.picture ?? null,
   }
 }
+
+// React.cache()로 래핑 — 같은 요청 내 여러 번 호출해도 실제 1회만 실행
+export const getAuthUser = cache(async () => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  return user
+})


### PR DESCRIPTION
## Summary
성능 최적화: 인증 중복 호출 제거, Suspense 스트리밍, 스켈레톤 UI 추가.

- `getAuthUser()`를 `React.cache()`로 래핑하여 레이아웃+페이지 중복 호출 제거
- 문서 목록/상세 콘텐츠를 별도 async Server Component로 분리 + `<Suspense>` 적용
- `DocumentListSkeleton` 카드형 스켈레톤 컴포넌트 신규 생성
- `loading.tsx` 추가 (문서 목록, 문서 상세 라우트)
- 문서 상세 페이지에서 `Promise.all([getAuthUser(), params])`로 병렬화

## Type of Change
- [x] feat: 새로운 기능

## Test Plan
- [ ] `npm run build` 후 네트워크 탭에서 streaming 동작 확인
- [ ] 문서 목록 페이지 접근 시 스켈레톤 UI → 실제 콘텐츠 순서 확인
- [ ] 문서 상세 페이지 접근 시 스켈레톤 → 콘텐츠 스트리밍 확인
- [ ] 라우트 전환 시 loading.tsx 표시 확인
- [ ] 인증 실패 시 /login 리다이렉트 정상 동작 확인

## Checklist
- [x] 셀프 리뷰 완료
- [x] 타입 체크 통과 (`npm run typecheck`)
- [x] 린트 통과 (`npm run lint`)
- [x] Breaking change 없음