### PR TITLE
feat: add metadata, error boundaries, 404 page, and robots.txt

### DIFF
--- a/app/(dashboard)/error.tsx
+++ b/app/(dashboard)/error.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useEffect } from "react"
+import { Button } from "@/components/ui/button"
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error("Dashboard error:", error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4">
+      <h1 className="text-2xl font-bold">문제가 발생했습니다</h1>
+      <p className="text-muted-foreground">
+        페이지를 불러오는 중 오류가 발생했습니다.
+      </p>
+      <Button onClick={reset}>다시 시도</Button>
+    </div>
+  )
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useEffect } from "react"
+import { Button } from "@/components/ui/button"
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error("Unhandled error:", error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4">
+      <h1 className="text-2xl font-bold">문제가 발생했습니다</h1>
+      <p className="text-muted-foreground">
+        예기치 않은 오류가 발생했습니다. 다시 시도해 주세요.
+      </p>
+      <Button onClick={reset}>다시 시도</Button>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import { Geist_Mono } from "next/font/google"
 import localFont from "next/font/local"
 
@@ -17,6 +18,14 @@ const fontMono = Geist_Mono({
   subsets: ["latin"],
   variable: "--font-mono",
 })
+
+export const metadata: Metadata = {
+  title: {
+    default: "Resume Manager",
+    template: "%s | Resume Manager",
+  },
+  description: "이력서, 자기소개서, 경력기술서 작성을 돕는 이력서 관리 서비스",
+}
 
 export default function RootLayout({
   children,

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4">
+      <h1 className="text-4xl font-bold">404</h1>
+      <p className="text-muted-foreground text-lg">
+        페이지를 찾을 수 없습니다
+      </p>
+      <Button asChild>
+        <Link href="/">홈으로 돌아가기</Link>
+      </Button>
+    </div>
+  )
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      disallow: "/",
+    },
+  }
+}


### PR DESCRIPTION
## Summary
에러 인프라 구축: 메타데이터, Error Boundary, 404 페이지, robots.txt.

- Root layout에 `metadata` export 추가 (title template, description)
- 전역 Error Boundary (`app/error.tsx`) — 예기치 않은 에러 시 "다시 시도" UI
- 대시보드 Error Boundary (`app/(dashboard)/error.tsx`) — 사이드바 유지하며 에러 표시
- 커스텀 404 페이지 (`app/not-found.tsx`)
- `robots.ts` — 인증 필수 서비스이므로 모든 크롤러 차단

## Type of Change
- [x] feat: 새로운 기능

## Test Plan
- [ ] 존재하지 않는 URL 접근 시 커스텀 404 페이지 표시 확인
- [ ] /robots.txt 접근 시 Disallow: / 확인
- [ ] 브라우저 탭 타이틀에 "Resume Manager" 표시 확인
- [ ] 서버 컴포넌트에서 에러 발생 시 Error Boundary UI 표시 확인

## Checklist
- [x] 셀프 리뷰 완료
- [x] 타입 체크 통과 (`npm run typecheck`)
- [x] 린트 통과 (`npm run lint`)
- [x] Breaking change 없음