### PR TITLE
fix: improve data robustness with abort handler, chunk limits, and validation

### DIFF
--- a/components/documents/document-card.tsx
+++ b/components/documents/document-card.tsx
@@ -84,7 +84,7 @@ export function DocumentCard({
           <CardDescription className="flex items-center gap-2">
             <span>{formatFileSize(document.fileSize)}</span>
             <span>·</span>
-            <span>{formatDate(document.createdAt)}</span>
+            <span suppressHydrationWarning>{formatDate(document.createdAt)}</span>
             <span>·</span>
             <span>{document._count.chunks}개 청크</span>
           </CardDescription>

--- a/hooks/use-file-upload.ts
+++ b/hooks/use-file-upload.ts
@@ -75,6 +75,13 @@ export function useFileUpload({ onSuccess }: UseFileUploadOptions = {}) {
           resolve(null)
         })
 
+        xhr.addEventListener("abort", () => {
+          xhrRef.current = null
+          setIsUploading(false)
+          setProgress(0)
+          resolve(null)
+        })
+
         xhr.open("POST", "/api/documents")
         xhr.send(formData)
       })

--- a/lib/documents/service.ts
+++ b/lib/documents/service.ts
@@ -70,7 +70,15 @@ export async function uploadDocument(
     throw new DocumentValidationError("파일에서 텍스트를 추출할 수 없습니다.")
   }
 
-  const chunks = splitIntoChunks(extractedText)
+  const MAX_CHUNKS = 500
+  let chunks = splitIntoChunks(extractedText)
+
+  if (chunks.length > MAX_CHUNKS) {
+    console.warn(
+      `청크 수 제한 초과: ${chunks.length}개 → ${MAX_CHUNKS}개만 저장`,
+    )
+    chunks = chunks.slice(0, MAX_CHUNKS)
+  }
 
   // DB 저장 (트랜잭션)
   let document: { id: string }
@@ -111,6 +119,13 @@ export async function uploadDocument(
   if (chunks.length > 0) {
     try {
       const embeddings = await generateEmbeddings(chunks)
+
+      // NaN/Infinity 검증
+      for (const embedding of embeddings) {
+        if (embedding.some((v) => !Number.isFinite(v))) {
+          throw new Error("임베딩에 유효하지 않은 값(NaN/Infinity)이 포함됨")
+        }
+      }
 
       const dbChunks = await prisma.documentChunk.findMany({
         where: { documentId: document.id },


### PR DESCRIPTION
## Summary
데이터 견고성 개선: XHR abort 처리, 청크 수 제한, 임베딩 검증, hydration 경고 수정.

- XHR abort 이벤트 핸들러 추가 (Promise 미해소 방지)
- 대량 문서 청크 제한 (MAX_CHUNKS = 500, 초과 시 경고 로그 + 앞부분만 저장)
- 임베딩 생성 후 NaN/Infinity 검증 추가
- 날짜 표시에 `suppressHydrationWarning` 적용 (서버/클라이언트 타임존 차이 대응)

**의존**: feature/a11y-fixes 머지 후 develop에 리베이스 필요 (document-card.tsx 충돌 방지)

## Type of Change
- [x] fix: 버그 수정

## Test Plan
- [ ] 업로드 중 다이얼로그 닫기(컴포넌트 언마운트) 시 에러 없음 확인
- [ ] 500개 이상 청크 생성되는 대용량 문서 업로드 시 경고 로그 + 정상 저장 확인
- [ ] 날짜 표시에 hydration 경고 없음 확인

## Checklist
- [x] 셀프 리뷰 완료
- [x] 타입 체크 통과 (`npm run typecheck`)
- [x] 린트 통과 (`npm run lint`)
- [x] Breaking change 없음