### PR TITLE
style(theme): add color-scheme, CSS type vars, localize UI text, and fix transitions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+    color-scheme: light dark;
     --background: oklch(1 0 0);
     --foreground: oklch(0.145 0 0);
     --card: oklch(1 0 0);
@@ -37,6 +38,9 @@
     --sidebar-accent-foreground: oklch(0.205 0 0);
     --sidebar-border: oklch(0.922 0 0);
     --sidebar-ring: oklch(0.708 0 0);
+    --type-pdf: oklch(0.637 0.237 25.331);
+    --type-docx: oklch(0.623 0.214 259.815);
+    --type-txt: oklch(0.556 0 0);
 }
 
 .dark {
@@ -71,6 +75,9 @@
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(1 0 0 / 10%);
     --sidebar-ring: oklch(0.556 0 0);
+    --type-pdf: oklch(0.704 0.191 22.216);
+    --type-docx: oklch(0.623 0.214 259.815);
+    --type-txt: oklch(0.708 0 0);
 }
 
 @theme inline {
@@ -106,6 +113,9 @@
     --color-card: var(--card);
     --color-foreground: var(--foreground);
     --color-background: var(--background);
+    --color-type-pdf: var(--type-pdf);
+    --color-type-docx: var(--type-docx);
+    --color-type-txt: var(--type-txt);
     --radius-sm: calc(var(--radius) * 0.6);
     --radius-md: calc(var(--radius) * 0.8);
     --radius-lg: var(--radius);

--- a/components/documents/document-card.tsx
+++ b/components/documents/document-card.tsx
@@ -46,9 +46,9 @@ const typeIcons: Record<DocumentType, typeof FileText> = {
 }
 
 const typeColors: Record<DocumentType, string> = {
-  pdf: "text-red-500",
-  docx: "text-blue-500",
-  txt: "text-gray-500",
+  pdf: "text-type-pdf",
+  docx: "text-type-docx",
+  txt: "text-type-txt",
 }
 
 function formatDate(dateStr: string): string {

--- a/components/documents/document-upload.tsx
+++ b/components/documents/document-upload.tsx
@@ -180,7 +180,7 @@ export function DocumentUpload({ onSuccess }: DocumentUploadProps) {
               className="bg-muted h-2 w-full overflow-hidden rounded-full"
             >
               <div
-                className="bg-primary h-full transition-all duration-300"
+                className="bg-primary h-full transition-[width] duration-300"
                 style={{ width: `${progress}%` }}
               />
             </div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,11 +5,11 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow,opacity,transform] outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -76,7 +76,7 @@ function DialogContent({
             >
               <XIcon
               />
-              <span className="sr-only">Close</span>
+              <span className="sr-only">닫기</span>
             </Button>
           </DialogPrimitive.Close>
         )}
@@ -115,7 +115,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button variant="outline">닫기</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -271,7 +271,7 @@ function SidebarTrigger({
       {...props}
     >
       <PanelLeftIcon />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">사이드바 토글</span>
     </Button>
   )
 }
@@ -283,10 +283,10 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
     <button
       data-sidebar="rail"
       data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
+      aria-label="사이드바 토글"
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title="사이드바 토글"
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",

--- a/docs/references/spec-deviations.md
+++ b/docs/references/spec-deviations.md
@@ -69,3 +69,21 @@
 - **스펙**: `claude-sonnet-4-6`
 - **실제**: `claude-sonnet-4-20250514`
 - **이유**: AI SDK에서 사용하는 정식 모델 ID (날짜 기반 버전 형식)
+
+## shadcn/ui 컴포넌트 수정
+
+아래 shadcn/ui 생성 파일에 프로젝트 요구사항에 맞는 커스터마이징 적용:
+
+### `components/ui/button.tsx`
+
+- `transition-all` → `transition-[color,background-color,border-color,box-shadow,opacity,transform]` (성능 개선)
+- default variant `[a]:hover:bg-primary/80` → `hover:bg-primary/80` (일반 hover로 수정)
+
+### `components/ui/dialog.tsx`
+
+- sr-only "Close" → "닫기" (한국어 서비스)
+- Footer close 버튼 텍스트 "Close" → "닫기"
+
+### `components/ui/sidebar.tsx`
+
+- "Toggle Sidebar" → "사이드바 토글" (한국어 서비스)


### PR DESCRIPTION
## Summary
테마/다크모드 품질 개선: CSS 변수 기반 타입 색상, color-scheme, 한국어 UI 텍스트, transition 최적화.

- `:root`에 `color-scheme: light dark` 추가
- 문서 타입별 CSS 변수 (`--type-pdf`, `--type-docx`, `--type-txt`) light/dark 분기
- document-card의 하드코딩 `text-red-500` 등 → CSS 변수 기반 클래스
- Button `transition-all` → 개별 속성 명시 (성능 개선)
- Button default variant `[a]:hover:` → 일반 `hover:` 수정
- Dialog sr-only "Close" → "닫기", Footer 버튼 텍스트 "Close" → "닫기"
- Sidebar "Toggle Sidebar" → "사이드바 토글"
- Progress bar `transition-all` → `transition-[width]`
- `spec-deviations.md`에 shadcn/ui 파일 변경 기록

## Type of Change
- [x] style: UI/스타일 변경

## Test Plan
- [ ] 라이트/다크 모드 전환 시 문서 타입 아이콘 색상 정상 반영 확인
- [ ] Button hover 상태 정상 동작 확인
- [ ] Dialog 닫기 버튼 스크린리더 "닫기" 텍스트 확인
- [ ] 사이드바 토글 버튼 aria-label "사이드바 토글" 확인
- [ ] 업로드 progress bar 애니메이션 부드러움 확인

## Checklist
- [x] 셀프 리뷰 완료
- [x] 타입 체크 통과 (`npm run typecheck`)
- [x] 린트 통과 (`npm run lint`)
- [x] Breaking change 없음