### PR TITLE
feat(ux): add text truncation, optimistic delete, and ellipsis normalization

### DIFF
--- a/app/(dashboard)/documents/[id]/page.tsx
+++ b/app/(dashboard)/documents/[id]/page.tsx
@@ -33,9 +33,9 @@ async function DocumentContent({
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>
-        <div className="flex-1">
+        <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-bold">{document.title}</h1>
+            <h1 className="truncate text-2xl font-bold">{document.title}</h1>
             <Badge variant="secondary">
               {DOCUMENT_TYPE_LABELS[document.type as DocumentType] ?? document.type}
             </Badge>

--- a/app/(dashboard)/documents/page.tsx
+++ b/app/(dashboard)/documents/page.tsx
@@ -27,7 +27,7 @@ export default async function DocumentsPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">참고자료</h1>
+          <h1 className="text-2xl font-bold text-balance">참고자료</h1>
           <p className="text-muted-foreground mt-1">
             이력서, 경력기술서 등 참고 문서를 관리합니다
           </p>

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -1,7 +1,7 @@
 export default function DashboardPage() {
   return (
     <div>
-      <h1 className="text-2xl font-bold">
+      <h1 className="text-2xl font-bold text-balance">
         Resume Manager에 오신 것을 환영합니다
       </h1>
       <p className="text-muted-foreground mt-2">

--- a/components/documents/delete-button.tsx
+++ b/components/documents/delete-button.tsx
@@ -55,7 +55,7 @@ export function DeleteButton({ documentId, documentTitle }: DeleteButtonProps) {
       <AlertDialogTrigger asChild>
         <Button variant="destructive" size="sm" disabled={isDeleting}>
           <Trash2 aria-hidden="true" className="mr-2 h-4 w-4" />
-          {isDeleting ? "삭제 중..." : "삭제"}
+          {isDeleting ? "삭제 중\u2026" : "삭제"}
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>

--- a/components/documents/document-list.tsx
+++ b/components/documents/document-list.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useOptimistic, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { FileText } from "lucide-react"
 import { toast } from "sonner"
@@ -22,11 +22,22 @@ interface DocumentListProps {
 
 export function DocumentList({ documents }: DocumentListProps) {
   const router = useRouter()
-  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
+  const [, startTransition] = useTransition()
+
+  const [optimisticDocs, removeOptimistic] = useOptimistic(
+    documents,
+    (state, deletedId: string) => state.filter((doc) => doc.id !== deletedId),
+  )
 
   const handleDelete = useCallback(
     async (id: string) => {
-      setDeletingId(id)
+      setDeletingIds((prev) => new Set(prev).add(id))
+
+      startTransition(() => {
+        removeOptimistic(id)
+      })
+
       try {
         const res = await fetch(`/api/documents/${id}`, { method: "DELETE" })
         const data = await res.json()
@@ -41,14 +52,19 @@ export function DocumentList({ documents }: DocumentListProps) {
         const message =
           err instanceof Error ? err.message : "삭제에 실패했습니다."
         toast.error(message)
+        router.refresh()
       } finally {
-        setDeletingId(null)
+        setDeletingIds((prev) => {
+          const next = new Set(prev)
+          next.delete(id)
+          return next
+        })
       }
     },
-    [router],
+    [router, removeOptimistic, startTransition],
   )
 
-  if (documents.length === 0) {
+  if (optimisticDocs.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16">
         <FileText aria-hidden="true" className="text-muted-foreground mb-4 h-12 w-12" />
@@ -64,12 +80,12 @@ export function DocumentList({ documents }: DocumentListProps) {
 
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {documents.map((doc) => (
+      {optimisticDocs.map((doc) => (
         <DocumentCard
           key={doc.id}
           document={doc}
           onDelete={handleDelete}
-          isDeleting={deletingId === doc.id}
+          isDeleting={deletingIds.has(doc.id)}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
UX/콘텐츠 품질 개선: 텍스트 오버플로 방지, optimistic UI, 말줄임표 통일.

- 문서 상세 페이지 h1에 `truncate` + flex 자식에 `min-w-0` 추가 (긴 제목 대응)
- 대시보드/문서 목록 h1에 `text-balance` 추가
- 말줄임표 `...` → `\u2026` (Unicode ellipsis) 일괄 적용
- `deletingId: string` → `deletingIds: Set<string>` (동시 삭제 지원)
- `useOptimistic`으로 삭제 시 즉시 카드 제거 → `router.refresh()` 백그라운드 동기화

## Type of Change
- [x] feat: 새로운 기능

## Test Plan
- [ ] 100자 이상 긴 제목 문서에서 오버플로 없이 truncate 확인
- [ ] 삭제 버튼 클릭 시 카드 즉시 사라짐 (optimistic) 확인
- [ ] 여러 문서 동시 삭제 시 각각 독립적으로 동작 확인
- [ ] 삭제 실패 시 카드 복원 확인
- [ ] 말줄임표 문자 "…" 정상 표시 확인

## Checklist
- [x] 셀프 리뷰 완료
- [x] 타입 체크 통과 (`npm run typecheck`)
- [x] 린트 통과 (`npm run lint`)
- [x] Breaking change 없음