### PR TITLE
style(design): add animations, sticky topbar, card shadows, and motion preferences

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -125,6 +125,21 @@
     --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.3s ease-out both;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -135,4 +150,21 @@
   html {
     @apply font-sans;
     }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@layer base {
+  button, a, [role="button"] {
+    touch-action: manipulation;
+  }
+  h1, h2, h3 {
+    letter-spacing: -0.025em;
+  }
 }

--- a/components/documents/document-card.tsx
+++ b/components/documents/document-card.tsx
@@ -69,7 +69,7 @@ export function DocumentCard({
   const label = DOCUMENT_TYPE_LABELS[docType] ?? document.type
 
   return (
-    <Card className="group relative">
+    <Card className="group relative transition-shadow hover:shadow-md">
       <Link href={`/documents/${document.id}`}>
         <CardHeader>
           <div className="flex items-start justify-between">

--- a/components/documents/document-list.tsx
+++ b/components/documents/document-list.tsx
@@ -80,13 +80,18 @@ export function DocumentList({ documents }: DocumentListProps) {
 
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {optimisticDocs.map((doc) => (
-        <DocumentCard
+      {optimisticDocs.map((doc, index) => (
+        <div
           key={doc.id}
-          document={doc}
-          onDelete={handleDelete}
-          isDeleting={deletingIds.has(doc.id)}
-        />
+          className="animate-fade-in-up"
+          style={{ animationDelay: `${index * 50}ms` }}
+        >
+          <DocumentCard
+            document={doc}
+            onDelete={handleDelete}
+            isDeleting={deletingIds.has(doc.id)}
+          />
+        </div>
       ))}
     </div>
   )

--- a/components/layout/topbar.tsx
+++ b/components/layout/topbar.tsx
@@ -10,7 +10,7 @@ export function Topbar() {
   const title = getPageTitle(pathname)
 
   return (
-    <header className="flex h-14 items-center gap-2 border-b px-4">
+    <header className="bg-background/80 sticky top-0 z-10 flex h-14 items-center gap-2 border-b px-4 backdrop-blur-sm">
       <SidebarTrigger />
       <Separator orientation="vertical" className="h-6" />
       {title && <h1 className="text-sm font-medium">{title}</h1>}


### PR DESCRIPTION
## Summary
비주얼 디자인 개선: 애니메이션, 스티키 헤더, 카드 그림자, 모션 접근성.

- `@keyframes fade-in-up` + `.animate-fade-in-up` 정의
- 문서 카드 stagger 애니메이션 (`animationDelay: index * 50ms`)
- `prefers-reduced-motion: reduce` 미디어 쿼리 (애니메이션/트랜지션 비활성화)
- `touch-action: manipulation` (버튼, 링크, role="button")
- 제목 `letter-spacing: -0.025em` (tracking-tight)
- Topbar `sticky top-0 z-10 bg-background/80 backdrop-blur-sm`
- Document card `hover:shadow-md transition-shadow`

**의존**: feature/theme-quality 머지 후 develop에 리베이스 필요

## Type of Change
- [x] style: UI/스타일 변경

## Test Plan
- [ ] 문서 목록 페이지 진입 시 카드 순차적으로 fade-in 확인
- [ ] `prefers-reduced-motion: reduce` 설정 시 애니메이션 없음 확인
- [ ] Topbar 스크롤 시 sticky + 블러 효과 확인
- [ ] 카드 호버 시 그림자 표시 확인
- [ ] 모바일에서 터치 반응성 확인

## Checklist
- [x] 셀프 리뷰 완료
- [x] 타입 체크 통과 (`npm run typecheck`)
- [x] 린트 통과 (`npm run lint`)
- [x] Breaking change 없음