### PR TITLE
feat(dashboard): add quick-start cards and document count widget

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -1,12 +1,77 @@
-export default function DashboardPage() {
+import { redirect } from "next/navigation"
+import Link from "next/link"
+import { FileText, Upload, Sparkles } from "lucide-react"
+
+import { createClient } from "@/lib/supabase/server"
+import { countDocuments } from "@/lib/documents/service"
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+
+export default async function DashboardPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) redirect("/login")
+
+  const documentCount = await countDocuments(user.id)
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-balance">
-        Resume Manager에 오신 것을 환영합니다
-      </h1>
-      <p className="text-muted-foreground mt-2">
-        사이드바에서 원하는 메뉴를 선택하세요.
-      </p>
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-balance">
+          Resume Manager에 오신 것을 환영합니다
+        </h1>
+        <p className="text-muted-foreground mt-2">
+          이력서와 경력 문서를 관리하고 AI의 도움을 받아보세요.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <Card className="animate-fade-in-up">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="bg-primary/10 text-primary rounded-lg p-2">
+                <FileText className="h-5 w-5" />
+              </div>
+              <div>
+                <CardDescription>업로드된 문서</CardDescription>
+                <CardTitle className="text-2xl">{documentCount}</CardTitle>
+              </div>
+            </div>
+          </CardHeader>
+        </Card>
+
+        <Link href="/documents" className="animate-fade-in-up" style={{ animationDelay: "50ms" }}>
+          <Card className="h-full transition-shadow hover:shadow-md">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <div className="bg-primary/10 text-primary rounded-lg p-2">
+                  <Upload className="h-5 w-5" />
+                </div>
+                <div>
+                  <CardTitle className="text-base">문서 업로드</CardTitle>
+                  <CardDescription>PDF, DOCX, TXT 파일 업로드</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+          </Card>
+        </Link>
+
+        <Card className="animate-fade-in-up" style={{ animationDelay: "100ms" }}>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="bg-muted text-muted-foreground rounded-lg p-2">
+                <Sparkles className="h-5 w-5" />
+              </div>
+              <div>
+                <CardTitle className="text-base">AI 어시스턴트</CardTitle>
+                <CardDescription>곧 출시 예정</CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+        </Card>
+      </div>
     </div>
   )
 }

--- a/lib/documents/service.ts
+++ b/lib/documents/service.ts
@@ -207,6 +207,13 @@ export async function listDocuments(userId: string) {
   })
 }
 
+// 사용자 문서 수 조회
+export async function countDocuments(userId: string) {
+  return prisma.document.count({
+    where: { userId },
+  })
+}
+
 // 문서 상세 조회 (소유권 검증 포함)
 export async function getDocument(documentId: string, userId: string) {
   const document = await prisma.document.findUnique({


### PR DESCRIPTION
## Summary
대시보드 콘텐츠 개선: 빠른 시작 카드, 문서 수 통계 위젯 추가.

- `countDocuments(userId)` 헬퍼 함수 추가
- 기존 텍스트 환영 메시지 → 카드 기반 대시보드 레이아웃
- 업로드된 문서 수 통계 위젯
- 문서 업로드 바로가기 카드
- AI 어시스턴트 티저 카드 (곧 출시 예정)
- fade-in-up stagger 애니메이션 적용

**의존**: feature/design-visual 머지 후 develop에 리베이스 필요

## Type of Change
- [x] feat: 새로운 기능

## Test Plan
- [ ] 대시보드 페이지에서 문서 수 정확히 표시 확인
- [ ] "문서 업로드" 카드 클릭 시 /documents 이동 확인
- [ ] 카드 순차적 fade-in 애니메이션 확인
- [ ] 로그인 후 대시보드 정상 렌더링 확인

## Checklist
- [x] 셀프 리뷰 완료
- [x] 타입 체크 통과 (`npm run typecheck`)
- [x] 린트 통과 (`npm run lint`)
- [x] Breaking change 없음