### PR TITLE
fix(token-usage): GROUP BY 파라미터 바인딩 에러 수정

### DIFF
--- a/lib/token-usage/service.ts
+++ b/lib/token-usage/service.ts
@@ -112,8 +112,8 @@ export async function getUserUsageSummary(
       WHERE user_id = ${userId}::uuid
         AND created_at >= ${startDate}
         AND created_at <= ${endDate}
-      GROUP BY DATE(created_at AT TIME ZONE ${tz})
-      ORDER BY date ASC
+      GROUP BY 1
+      ORDER BY 1 ASC
     `,
   ])
 


### PR DESCRIPTION
## Summary
토큰 사용량 요약 API(`GET /api/token-usage/summary`)에서 Prisma `$queryRaw`의 파라미터 바인딩으로 인해 PostgreSQL이 GROUP BY 표현식을 매칭하지 못하는 42803 에러 수정

## Related Issues
Closes #68

## Type of Change
- [x] fix: 버그 수정

## Test Plan
- [x] `/usage` 페이지에서 토큰 사용량 요약 정상 로드 확인 (200 응답)
- [x] Asia/Seoul timezone으로 조회 시 에러 없이 응답 확인

## Checklist
- [x] 셀프 리뷰 완료
- [x] 타입 체크 통과 (`npm run typecheck`)
- [x] 린트 통과 (`npm run lint`)
- [x] Breaking change 없음