### PR TITLE
fix(a11y): 카드 컴포넌트 event-stop div 접근성 개선

### DIFF
--- a/components/career-notes/career-note-card.tsx
+++ b/components/career-notes/career-note-card.tsx
@@ -128,7 +128,10 @@ export function CareerNoteCard({ note, onEdit, onDelete, isDeleting }: CareerNot
           size="icon"
           className="h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
           aria-label="커리어노트 수정"
-          onClick={(e) => { e.stopPropagation(); onEdit(note) }}
+          onClick={(e) => {
+            e.stopPropagation()
+            onEdit(note)
+          }}
           onKeyDown={(e) => e.stopPropagation()}
           disabled={isDeleting}
         >

--- a/components/career-notes/career-note-card.tsx
+++ b/components/career-notes/career-note-card.tsx
@@ -122,17 +122,14 @@ export function CareerNoteCard({ note, onEdit, onDelete, isDeleting }: CareerNot
           </div>
         )}
       </CardContent>
-      <div
-        className="absolute right-2 top-2 flex gap-1"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="absolute right-2 top-2 flex gap-1">
         <Button
           variant="ghost"
           size="icon"
-          className="h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100"
+          className="h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
           aria-label="커리어노트 수정"
-          onClick={() => onEdit(note)}
+          onClick={(e) => { e.stopPropagation(); onEdit(note) }}
+          onKeyDown={(e) => e.stopPropagation()}
           disabled={isDeleting}
         >
           <Pencil aria-hidden="true" className="h-4 w-4" />
@@ -142,9 +139,11 @@ export function CareerNoteCard({ note, onEdit, onDelete, isDeleting }: CareerNot
             <Button
               variant="ghost"
               size="icon"
-              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100"
+              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
               aria-label="커리어노트 삭제"
               disabled={isDeleting}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
             >
               <Trash2 aria-hidden="true" className="h-4 w-4" />
             </Button>

--- a/components/cover-letters/cover-letter-card.tsx
+++ b/components/cover-letters/cover-letter-card.tsx
@@ -72,19 +72,17 @@ export function CoverLetterCard({
         </CardHeader>
       </Link>
 
-      <div
-        className="absolute right-2 bottom-2"
-        onClick={(e) => { e.preventDefault(); e.stopPropagation() }}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="absolute right-2 bottom-2">
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
               aria-label="자기소개서 삭제"
-              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
               disabled={isDeleting}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
             >
               <Trash2 aria-hidden="true" className="h-4 w-4" />
             </Button>

--- a/components/documents/document-card.tsx
+++ b/components/documents/document-card.tsx
@@ -83,19 +83,17 @@ export function DocumentCard({
         </CardHeader>
       </Link>
 
-      <div
-        className="absolute right-2 bottom-2"
-        onClick={(e) => { e.preventDefault(); e.stopPropagation() }}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="absolute right-2 bottom-2">
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
               aria-label="문서 삭제"
-              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
               disabled={isDeleting}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
             >
               <Trash2 aria-hidden="true" className="h-4 w-4" />
             </Button>

--- a/components/external-documents/external-document-card.tsx
+++ b/components/external-documents/external-document-card.tsx
@@ -88,19 +88,17 @@ export function ExternalDocumentCard({
         </CardHeader>
       </Link>
 
-      <div
-        className="absolute right-2 bottom-2"
-        onClick={(e) => { e.preventDefault(); e.stopPropagation() }}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="absolute right-2 bottom-2">
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
               aria-label="외부 문서 삭제"
-              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
               disabled={isDeleting}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
             >
               <Trash2 aria-hidden="true" className="h-4 w-4" />
             </Button>

--- a/components/insights/insight-card.tsx
+++ b/components/insights/insight-card.tsx
@@ -93,7 +93,10 @@ export function InsightCard({ insight, onEdit, onDelete, isDeleting }: InsightCa
           size="icon"
           className="h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
           aria-label="인사이트 수정"
-          onClick={(e) => { e.stopPropagation(); onEdit(insight) }}
+          onClick={(e) => {
+            e.stopPropagation()
+            onEdit(insight)
+          }}
           onKeyDown={(e) => e.stopPropagation()}
           disabled={isDeleting}
         >

--- a/components/insights/insight-card.tsx
+++ b/components/insights/insight-card.tsx
@@ -87,17 +87,14 @@ export function InsightCard({ insight, onEdit, onDelete, isDeleting }: InsightCa
           {insight.content}
         </p>
       </CardContent>
-      <div
-        className="absolute right-2 top-2 flex gap-1"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="absolute right-2 top-2 flex gap-1">
         <Button
           variant="ghost"
           size="icon"
-          className="h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100"
+          className="h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
           aria-label="인사이트 수정"
-          onClick={() => onEdit(insight)}
+          onClick={(e) => { e.stopPropagation(); onEdit(insight) }}
+          onKeyDown={(e) => e.stopPropagation()}
           disabled={isDeleting}
         >
           <Pencil aria-hidden="true" className="h-4 w-4" />
@@ -107,9 +104,11 @@ export function InsightCard({ insight, onEdit, onDelete, isDeleting }: InsightCa
             <Button
               variant="ghost"
               size="icon"
-              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100"
+              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
               aria-label="인사이트 삭제"
               disabled={isDeleting}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
             >
               <Trash2 aria-hidden="true" className="h-4 w-4" />
             </Button>

--- a/components/interviews/interview-card.tsx
+++ b/components/interviews/interview-card.tsx
@@ -73,19 +73,17 @@ export function InterviewCard({
         <span suppressHydrationWarning>{formatDate(updatedAt)}</span>
       </div>
 
-      <div
-        className="absolute right-2 bottom-2"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="absolute right-2 bottom-2">
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
               aria-label="면접 세션 삭제"
-              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
               disabled={isDeleting}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
             >
               <Trash2 aria-hidden="true" className="h-4 w-4" />
             </Button>

--- a/components/resumes/resume-card.tsx
+++ b/components/resumes/resume-card.tsx
@@ -64,19 +64,17 @@ export function ResumeCard({ resume, onDelete, isDeleting }: ResumeCardProps) {
         </CardHeader>
       </Link>
 
-      <div
-        className="absolute right-2 bottom-2"
-        onClick={(e) => { e.preventDefault(); e.stopPropagation() }}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="absolute right-2 bottom-2">
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
               aria-label="이력서 삭제"
-              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              className="text-muted-foreground hover:text-destructive h-8 w-8 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
               disabled={isDeleting}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
             >
               <Trash2 aria-hidden="true" className="h-4 w-4" />
             </Button>

--- a/docs/superpowers/specs/2026-03-26-ai-infra-doc-rewrite-design.md
+++ b/docs/superpowers/specs/2026-03-26-ai-infra-doc-rewrite-design.md
@@ -1,0 +1,69 @@
+# AI 인프라 문서 재작성 설계
+
+> 2026-03-26
+
+## 목적
+
+`docs/features/05-ai-infra.md`를 현재 코드에 맞게 재작성한다. 삭제된 tool use, multi-step/classification 파이프라인 분기 내용을 제거하고, 현행 단일 파이프라인 흐름을 중심으로 정리한다.
+
+## 배경
+
+PR #93(deterministic-routing 벤치마크 + 파이프라인 단순화)에서 채팅 파이프라인이 대폭 변경됨:
+
+- tool use 4개 도구 (`readDocument`, `readExternalDocument`, `readCareerNote`, `saveCareerNote`) 삭제
+- provider별 파이프라인 분기 (`selectPipeline`, `multi-step`, `classification`) 삭제
+- 단일 파이프라인으로 통합: 문서 전문 주입 → 압축 → streamText
+
+현재 `05-ai-infra.md`에는 삭제된 내용이 그대로 남아 있어 코드와 괴리 상당.
+
+## 문서 구조
+
+파이프라인 흐름 중심(요청 → 응답 순서)으로 구성한다.
+
+### 섹션 구성
+
+```
+# AI 인프라 — 채팅 파이프라인
+
+## 개요
+## 파이프라인 흐름도 (Mermaid)
+## 단계별 상세
+  ### 1. 인증 & 요청 검증
+  ### 2. 쿼터 체크
+  ### 3. 컨텍스트 빌드 + 모델 로딩 (병렬)
+  ### 4. 시스템 프롬프트
+  ### 5. 대화 압축
+  ### 6. 스트리밍 응답 & 후처리
+## 지원 모델
+## 주요 파일 맵
+```
+
+### 각 섹션 내용
+
+**개요**: 한 줄 요약 + 변경 배경 (tool-calling → classification → 전문 주입으로의 진화)
+
+**파이프라인 흐름도**: Mermaid flowchart. 인증 → 검증 → 소유권확인 → 쿼터 → [컨텍스트빌드 || 모델로딩] → 시스템프롬프트 → 압축판단 → streamText → onFinish(DB+토큰)
+
+**단계별 상세**:
+1. 인증 & 검증 — Supabase auth, Zod 스키마(`coverLetterChatSchema`/`interviewChatSchema`), 소유권 체크. cover-letter vs interview 차이(외부문서 조회 경로, 커리어노트 포함 여부)
+2. 쿼터 — `checkQuotaExceeded`: TOKENS/COST/REQUESTS × DAILY/MONTHLY
+3. 컨텍스트 + 모델 — `buildFullContext`(문서 전문 + 외부 문서 + 커리어노트), `getLanguageModel`(DB → factory). `Promise.all`로 병렬
+4. 시스템 프롬프트 — `buildCoverLetterSystemPrompt` / `buildInterviewSystemPrompt` 파라미터 설명
+5. 압축 — `compressIfNeeded`: 토큰 > contextWindow × 50% 시 이전 대화 LLM 요약, 최근 4턴 유지
+6. 응답 + 후처리 — `streamText` (tools 없음), `onFinish`에서 메시지 DB 저장 + `recordUsage` + 비용 계산(`ModelPricing`)
+
+**지원 모델**: `types/ai.ts`의 `PROVIDER_MODELS` 테이블
+
+**주요 파일 맵**: 파일 경로 ↔ 역할 테이블
+
+### 의도적 제외
+
+- 삭제된 tool use, multi-step, classification, selectPipeline 관련 내용
+- 벤치마크 인프라 (별도 문서 영역)
+- 채팅 UI 컴포넌트
+- 설정 페이지 / API key 관리
+
+## 작업 범위
+
+- `docs/features/05-ai-infra.md` 전체 재작성 (기존 내용 대체)
+- 새 파일 생성 없음


### PR DESCRIPTION
## Summary
카드 컴포넌트의 event-stop `<div onClick>` 래퍼에서 이벤트 핸들러를 제거하고 각 Button에 직접 `stopPropagation`을 적용하여 키보드 접근성을 개선합니다. `focus-visible:opacity-100`을 추가하여 키보드 포커스 시 버튼이 표시됩니다.

## Related Issues
Closes #79
Closes #90

## Type of Change
- [ ] feat: 새로운 기능
- [x] fix: 버그 수정
- [ ] refactor: 리팩터링
- [ ] style: UI/스타일 변경
- [ ] docs: 문서 수정
- [ ] chore: 설정/빌드 등 기타

## Test Plan
- [x] Tab 키로 카드 내 삭제/편집 버튼에 포커스 이동 확인
- [x] 포커스 시 버튼이 화면에 표시되는지 확인 (focus-visible:opacity-100)
- [x] Enter/Space로 삭제 다이얼로그 열리는지 확인
- [x] 버튼 클릭 시 카드 상세 페이지로 이동하지 않는지 확인 (stopPropagation)
- [x] 7개 카드 컴포넌트 동일 패턴 적용 확인

## Checklist
- [x] 셀프 리뷰 완료
- [x] 타입 체크 통과 (`npm run typecheck`)
- [ ] 린트 통과 (`npm run lint`)
- [x] Breaking change 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)