### PR TITLE
refactor: admin 영역 통합 개선 (#63, #64, #61)

### DIFF
--- a/app/(dashboard)/admin/model-pricing/page.tsx
+++ b/app/(dashboard)/admin/model-pricing/page.tsx
@@ -1,16 +1,8 @@
 "use client"
 
 import { useState, useEffect, useReducer, useCallback } from "react"
+import type { PricingEntry } from "@/types/admin"
 import { PricingTable } from "@/components/admin/pricing-table"
-
-interface PricingEntry {
-  id: string
-  provider: string
-  model: string
-  inputPricePerM: number
-  outputPricePerM: number
-  effectiveFrom: string
-}
 
 type FetchState =
   | { status: "loading" }

--- a/app/(dashboard)/admin/quotas/page.tsx
+++ b/app/(dashboard)/admin/quotas/page.tsx
@@ -1,17 +1,8 @@
 "use client"
 
 import { useState, useEffect, useReducer, useCallback } from "react"
+import type { QuotaEntry } from "@/types/admin"
 import { QuotaTable } from "@/components/admin/quota-table"
-
-interface QuotaEntry {
-  id: string
-  userId: string
-  limitType: string
-  limitValue: number
-  period: string
-  isActive: boolean
-  user: { email: string; name: string | null }
-}
 
 type FetchState =
   | { status: "loading" }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation"
 import { getAuthUser, extractUserInfo } from "@/lib/supabase/user"
-import { prisma } from "@/lib/prisma"
+import { getUserRole } from "@/lib/auth/get-user-role"
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar"
 import { AppSidebar } from "@/components/layout/app-sidebar"
 import { Topbar } from "@/components/layout/topbar"
@@ -16,11 +16,8 @@ export default async function DashboardLayout({
     redirect("/login")
   }
 
-  const dbUser = await prisma.user.findUnique({
-    where: { id: user.id },
-    select: { role: true },
-  })
-  const userInfo = { ...extractUserInfo(user), role: (dbUser?.role ?? "USER") as "ADMIN" | "USER" }
+  const role = await getUserRole(user.id)
+  const userInfo = { ...extractUserInfo(user), role }
 
   // !min-h-0: SidebarProvider 기본 min-h-svh를 해제하여 자식이 뷰포트를 넘지 않도록 제약
   return (

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -20,7 +20,7 @@ export default async function DashboardLayout({
     where: { id: user.id },
     select: { role: true },
   })
-  const userInfo = { ...extractUserInfo(user), role: dbUser?.role ?? "USER" }
+  const userInfo = { ...extractUserInfo(user), role: (dbUser?.role ?? "USER") as "ADMIN" | "USER" }
 
   // !min-h-0: SidebarProvider 기본 min-h-svh를 해제하여 자식이 뷰포트를 넘지 않도록 제약
   return (

--- a/components/admin/pricing-table.tsx
+++ b/components/admin/pricing-table.tsx
@@ -78,14 +78,14 @@ export function PricingTable({ data, onCreated }: PricingTableProps) {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle>모델 단가 목록</CardTitle>
-        <Dialog open={open} onOpenChange={setOpen}>
+        <Dialog open={open} onOpenChange={(v) => { setOpen(v); setError(""); }}>
           <DialogTrigger asChild>
             <Button size="sm">
               <Plus className="mr-1 h-4 w-4" />
               단가 추가
             </Button>
           </DialogTrigger>
-          <DialogContent>
+          <DialogContent key={String(open)}>
             <DialogHeader>
               <DialogTitle>모델 단가 추가</DialogTitle>
               <DialogDescription>AI 모델의 토큰 단가를 설정합니다.</DialogDescription>

--- a/components/admin/pricing-table.tsx
+++ b/components/admin/pricing-table.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import type { PricingEntry } from "@/types/admin"
 import {
   Table,
   TableBody,
@@ -29,15 +30,6 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Plus } from "lucide-react"
-
-interface PricingEntry {
-  id: string
-  provider: string
-  model: string
-  inputPricePerM: number
-  outputPricePerM: number
-  effectiveFrom: string
-}
 
 interface PricingTableProps {
   data: PricingEntry[]

--- a/components/admin/quota-table.tsx
+++ b/components/admin/quota-table.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { toast } from "sonner"
 import type { QuotaEntry } from "@/types/admin"
 import {
   Table,
@@ -96,7 +97,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
       }
       onChanged()
     } catch (err) {
-      alert(err instanceof Error ? err.message : "삭제에 실패했습니다.")
+      toast.error(err instanceof Error ? err.message : "삭제에 실패했습니다.")
     } finally {
       setDeletingId(null)
     }
@@ -106,14 +107,14 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle>Quota 목록</CardTitle>
-        <Dialog open={open} onOpenChange={setOpen}>
+        <Dialog open={open} onOpenChange={(v) => { setOpen(v); setError(""); }}>
           <DialogTrigger asChild>
             <Button size="sm">
               <Plus className="mr-1 h-4 w-4" />
               Quota 추가
             </Button>
           </DialogTrigger>
-          <DialogContent>
+          <DialogContent key={String(open)}>
             <DialogHeader>
               <DialogTitle>Quota 추가</DialogTitle>
               <DialogDescription>사용자별 사용량 한도를 설정합니다.</DialogDescription>

--- a/components/admin/quota-table.tsx
+++ b/components/admin/quota-table.tsx
@@ -57,6 +57,15 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
   const [editTarget, setEditTarget] = useState<QuotaEntry | null>(null)
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [editError, setEditError] = useState("")
+  const [editIsActive, setEditIsActive] = useState(true)
+  const [editKey, setEditKey] = useState(0)
+
+  function openEdit(quota: QuotaEntry) {
+    setEditTarget(quota)
+    setEditIsActive(quota.isActive)
+    setEditKey((k) => k + 1)
+    setEditError("")
+  }
 
   async function handleEdit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -67,7 +76,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
     const form = new FormData(e.currentTarget)
     const body = {
       limitValue: Number(form.get("limitValue")),
-      isActive: form.get("isActive") === "on",
+      isActive: editIsActive,
     }
 
     try {
@@ -261,7 +270,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
                     <Button
                       variant="ghost"
                       size="icon"
-                      onClick={() => setEditTarget(quota)}
+                      onClick={() => openEdit(quota)}
                     >
                       <Pencil className="h-4 w-4" />
                     </Button>
@@ -281,7 +290,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
         </Table>
       </CardContent>
       <Dialog open={editTarget !== null} onOpenChange={(v) => { if (!v) { setEditTarget(null); setEditError(""); } }}>
-        <DialogContent key={editTarget?.id}>
+        <DialogContent key={editKey}>
           <DialogHeader>
             <DialogTitle>Quota 수정</DialogTitle>
             <DialogDescription>
@@ -303,8 +312,8 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
             <div className="flex items-center gap-2">
               <Switch
                 id="edit-isActive"
-                name="isActive"
-                defaultChecked={editTarget?.isActive}
+                checked={editIsActive}
+                onCheckedChange={setEditIsActive}
               />
               <Label htmlFor="edit-isActive">활성</Label>
             </div>

--- a/components/admin/quota-table.tsx
+++ b/components/admin/quota-table.tsx
@@ -30,7 +30,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
-import { Plus, Trash2 } from "lucide-react"
+import { Plus, Pencil, Trash2 } from "lucide-react"
+import { Switch } from "@/components/ui/switch"
 
 interface QuotaTableProps {
   data: QuotaEntry[]
@@ -53,6 +54,40 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState("")
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [editTarget, setEditTarget] = useState<QuotaEntry | null>(null)
+  const [editSubmitting, setEditSubmitting] = useState(false)
+  const [editError, setEditError] = useState("")
+
+  async function handleEdit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (!editTarget) return
+    setEditSubmitting(true)
+    setEditError("")
+
+    const form = new FormData(e.currentTarget)
+    const body = {
+      limitValue: Number(form.get("limitValue")),
+      isActive: form.get("isActive") === "on",
+    }
+
+    try {
+      const res = await fetch(`/api/admin/quotas/${editTarget.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error ?? "수정에 실패했습니다.")
+      }
+      setEditTarget(null)
+      onChanged()
+    } catch (err) {
+      setEditError(err instanceof Error ? err.message : "오류가 발생했습니다.")
+    } finally {
+      setEditSubmitting(false)
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -184,7 +219,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
               <TableHead className="text-right">제한 값</TableHead>
               <TableHead>기간</TableHead>
               <TableHead>상태</TableHead>
-              <TableHead className="w-16" />
+              <TableHead className="w-24" />
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -222,7 +257,14 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
                       {quota.isActive ? "활성" : "비활성"}
                     </span>
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setEditTarget(quota)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
                     <Button
                       variant="ghost"
                       size="icon"
@@ -238,6 +280,43 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
           </TableBody>
         </Table>
       </CardContent>
+      <Dialog open={editTarget !== null} onOpenChange={(v) => { if (!v) { setEditTarget(null); setEditError(""); } }}>
+        <DialogContent key={editTarget?.id}>
+          <DialogHeader>
+            <DialogTitle>Quota 수정</DialogTitle>
+            <DialogDescription>
+              {editTarget?.user.email} — {LIMIT_LABELS[editTarget?.limitType ?? ""] ?? editTarget?.limitType} ({PERIOD_LABELS[editTarget?.period ?? ""] ?? editTarget?.period})
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleEdit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-limitValue">제한 값</Label>
+              <Input
+                id="edit-limitValue"
+                name="limitValue"
+                type="number"
+                min="1"
+                required
+                defaultValue={editTarget?.limitValue}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch
+                id="edit-isActive"
+                name="isActive"
+                defaultChecked={editTarget?.isActive}
+              />
+              <Label htmlFor="edit-isActive">활성</Label>
+            </div>
+            {editError && (
+              <p className="text-sm text-destructive">{editError}</p>
+            )}
+            <Button type="submit" disabled={editSubmitting} className="w-full">
+              {editSubmitting ? "수정 중..." : "수정"}
+            </Button>
+          </form>
+        </DialogContent>
+      </Dialog>
     </Card>
   )
 }

--- a/components/admin/quota-table.tsx
+++ b/components/admin/quota-table.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import type { QuotaEntry } from "@/types/admin"
 import {
   Table,
   TableBody,
@@ -29,16 +30,6 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Plus, Trash2 } from "lucide-react"
-
-interface QuotaEntry {
-  id: string
-  userId: string
-  limitType: string
-  limitValue: number
-  period: string
-  isActive: boolean
-  user: { email: string; name: string | null }
-}
 
 interface QuotaTableProps {
   data: QuotaEntry[]

--- a/components/admin/quota-table.tsx
+++ b/components/admin/quota-table.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/select"
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogHeader,
@@ -57,7 +58,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
   const [editTarget, setEditTarget] = useState<QuotaEntry | null>(null)
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [editError, setEditError] = useState("")
-  const [editIsActive, setEditIsActive] = useState(true)
+  const [editIsActive, setEditIsActive] = useState(false)
   const [editKey, setEditKey] = useState(0)
 
   function openEdit(quota: QuotaEntry) {
@@ -132,6 +133,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
   }
 
   async function handleDelete(id: string) {
+    if (!confirm("정말 삭제하시겠습니까?")) return
     setDeletingId(id)
     try {
       const res = await fetch(`/api/admin/quotas/${id}`, { method: "DELETE" })
@@ -320,9 +322,16 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
             {editError && (
               <p className="text-sm text-destructive">{editError}</p>
             )}
-            <Button type="submit" disabled={editSubmitting} className="w-full">
-              {editSubmitting ? "수정 중..." : "수정"}
-            </Button>
+            <div className="flex gap-2">
+              <Button type="submit" disabled={editSubmitting} className="flex-1">
+                {editSubmitting ? "수정 중..." : "수정"}
+              </Button>
+              <DialogClose asChild>
+                <Button type="button" variant="outline" className="flex-1">
+                  취소
+                </Button>
+              </DialogClose>
+            </div>
           </form>
         </DialogContent>
       </Dialog>

--- a/components/admin/quota-table.tsx
+++ b/components/admin/quota-table.tsx
@@ -31,6 +31,16 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { Plus, Pencil, Trash2 } from "lucide-react"
 import { Switch } from "@/components/ui/switch"
 
@@ -55,10 +65,11 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState("")
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
   const [editTarget, setEditTarget] = useState<QuotaEntry | null>(null)
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [editError, setEditError] = useState("")
-  const [editIsActive, setEditIsActive] = useState(false)
+  const [editIsActive, setEditIsActive] = useState<boolean | null>(null)
   const [editKey, setEditKey] = useState(0)
 
   function openEdit(quota: QuotaEntry) {
@@ -77,7 +88,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
     const form = new FormData(e.currentTarget)
     const body = {
       limitValue: Number(form.get("limitValue")),
-      isActive: editIsActive,
+      isActive: editIsActive ?? false,
     }
 
     try {
@@ -133,7 +144,6 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
   }
 
   async function handleDelete(id: string) {
-    if (!confirm("정말 삭제하시겠습니까?")) return
     setDeletingId(id)
     try {
       const res = await fetch(`/api/admin/quotas/${id}`, { method: "DELETE" })
@@ -146,6 +156,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
       toast.error(err instanceof Error ? err.message : "삭제에 실패했습니다.")
     } finally {
       setDeletingId(null)
+      setDeleteTargetId(null)
     }
   }
 
@@ -280,7 +291,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
                       variant="ghost"
                       size="icon"
                       disabled={deletingId === quota.id}
-                      onClick={() => handleDelete(quota.id)}
+                      onClick={() => setDeleteTargetId(quota.id)}
                     >
                       <Trash2 className="h-4 w-4" />
                     </Button>
@@ -314,7 +325,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
             <div className="flex items-center gap-2">
               <Switch
                 id="edit-isActive"
-                checked={editIsActive}
+                checked={editIsActive ?? false}
                 onCheckedChange={setEditIsActive}
               />
               <Label htmlFor="edit-isActive">활성</Label>
@@ -335,6 +346,25 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
           </form>
         </DialogContent>
       </Dialog>
+      <AlertDialog
+        open={deleteTargetId !== null}
+        onOpenChange={(v) => { if (!v) setDeleteTargetId(null) }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Quota를 삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription>
+              선택한 Quota가 삭제됩니다. 이 작업은 되돌릴 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction onClick={() => { if (deleteTargetId) handleDelete(deleteTargetId) }}>
+              삭제
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   )
 }

--- a/components/admin/quota-table.tsx
+++ b/components/admin/quota-table.tsx
@@ -279,22 +279,24 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
                       {quota.isActive ? "활성" : "비활성"}
                     </span>
                   </TableCell>
-                  <TableCell className="flex gap-1">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => openEdit(quota)}
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      disabled={deletingId === quota.id}
-                      onClick={() => setDeleteTargetId(quota.id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                  <TableCell>
+                    <div className="flex gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => openEdit(quota)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        disabled={deletingId === quota.id}
+                        onClick={() => setDeleteTargetId(quota.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               ))
@@ -348,7 +350,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
       </Dialog>
       <AlertDialog
         open={deleteTargetId !== null}
-        onOpenChange={(v) => { if (!v) setDeleteTargetId(null) }}
+        onOpenChange={() => {}}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -358,8 +360,8 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>취소</AlertDialogCancel>
-            <AlertDialogAction onClick={() => { if (deleteTargetId) handleDelete(deleteTargetId) }}>
+            <AlertDialogCancel onClick={() => setDeleteTargetId(null)}>취소</AlertDialogCancel>
+            <AlertDialogAction disabled={deletingId === deleteTargetId} onClick={() => { if (deleteTargetId) handleDelete(deleteTargetId) }}>
               삭제
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/components/admin/quota-table.tsx
+++ b/components/admin/quota-table.tsx
@@ -350,7 +350,7 @@ export function QuotaTable({ data, onChanged }: QuotaTableProps) {
       </Dialog>
       <AlertDialog
         open={deleteTargetId !== null}
-        onOpenChange={() => {}}
+        onOpenChange={(v) => { if (!v && !deletingId) setDeleteTargetId(null) }}
       >
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/docs/superpowers/plans/2026-03-26-bugfix-batch.md
+++ b/docs/superpowers/plans/2026-03-26-bugfix-batch.md
@@ -1,0 +1,1153 @@
+# Bugfix Batch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 5 open issues (#87, #63, #64, #61, #40) across 3 PRs.
+
+**Architecture:** PR 1 fixes TOCTOU race conditions in document services using `deleteMany` with compound where + P2025 catch. PR 2 consolidates admin improvements: `React.cache()` for query dedup, UI fixes, shared types, and a quota edit dialog. PR 3 replaces text loading fallbacks with Skeleton components.
+
+**Tech Stack:** Next.js App Router, Prisma ORM, React Server Components, shadcn/ui, Vitest
+
+---
+
+## PR 1: TOCTOU Pattern Fix (#87)
+
+Branch: `fix/toctou-document-service`
+
+### Task 1: Update deleteDocument tests for new behavior
+
+**Files:**
+- Modify: `tests/lib/documents/service.test.ts`
+
+**Context:** The current `deleteDocument` uses separate findUnique (ownership check) + delete (removal). We're changing to: findUnique (URL only) → deleteMany({ where: { id, userId } }) → storage delete on success. The Prisma `delete` only accepts unique fields in `where`, but `deleteMany` accepts any field combination. 403/404 are unified — both become NotFoundError.
+
+- [ ] **Step 1: Update the mock setup to include deleteMany**
+
+In the prisma mock at the top of the file, add `deleteMany`:
+
+```typescript
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    document: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}))
+```
+
+- [ ] **Step 2: Rewrite deleteDocument tests**
+
+Replace the entire `describe("deleteDocument()")` block with:
+
+```typescript
+describe("deleteDocument()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeleteFile.mockResolvedValue(undefined as never)
+    mockPrisma.document.deleteMany.mockResolvedValue({ count: 1 } as never)
+  })
+
+  describe("소유권 검증 (403/404 통합)", () => {
+    it("문서가 존재하지 않으면 DocumentNotFoundError를 던져야 한다", async () => {
+      // Arrange — deleteMany가 0 rows 영향
+      mockPrisma.document.findUnique.mockResolvedValue({
+        originalUrl: "storage/user-1/doc.pdf",
+      } as never)
+      mockPrisma.document.deleteMany.mockResolvedValue({ count: 0 } as never)
+
+      // Act & Assert
+      await expect(deleteDocument("doc-999", "user-1")).rejects.toThrow(
+        DocumentNotFoundError,
+      )
+    })
+
+    it("userId가 문서 소유자와 달라도 DocumentNotFoundError를 던져야 한다 (403/404 통합)", async () => {
+      // Arrange — findUnique는 문서를 찾지만, deleteMany에서 userId 불일치로 count: 0
+      mockPrisma.document.findUnique.mockResolvedValue({
+        originalUrl: "storage/owner-user/doc.pdf",
+      } as never)
+      mockPrisma.document.deleteMany.mockResolvedValue({ count: 0 } as never)
+
+      // Act & Assert
+      await expect(deleteDocument("doc-1", "other-user")).rejects.toThrow(
+        DocumentNotFoundError,
+      )
+      // Storage 삭제가 호출되지 않아야 한다
+      expect(mockDeleteFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("성공 경로", () => {
+    it("DB 삭제 후 Storage 파일을 삭제해야 한다", async () => {
+      // Arrange
+      const storagePath = "storage/user-1/resume.pdf"
+      mockPrisma.document.findUnique.mockResolvedValue({
+        originalUrl: storagePath,
+      } as never)
+      mockPrisma.document.deleteMany.mockResolvedValue({ count: 1 } as never)
+
+      // Act
+      await deleteDocument("doc-1", "user-1")
+
+      // Assert — deleteMany에 userId 조건이 포함되어야 한다
+      expect(mockPrisma.document.deleteMany).toHaveBeenCalledWith({
+        where: { id: "doc-1", userId: "user-1" },
+      })
+      // Storage 삭제는 DB 삭제 성공 후에만
+      expect(mockDeleteFile).toHaveBeenCalledWith(storagePath)
+    })
+
+    it("deleteFile이 실패해도 에러를 던지지 않아야 한다 (catch 무시)", async () => {
+      // Arrange
+      mockPrisma.document.findUnique.mockResolvedValue({
+        originalUrl: "storage/user-1/resume.pdf",
+      } as never)
+      mockPrisma.document.deleteMany.mockResolvedValue({ count: 1 } as never)
+      mockDeleteFile.mockRejectedValue(new Error("Storage 오류"))
+
+      // Act — 에러 없이 완료
+      await expect(deleteDocument("doc-1", "user-1")).resolves.toBeUndefined()
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx vitest run tests/lib/documents/service.test.ts`
+Expected: FAIL — deleteDocument still uses old findUnique+delete pattern
+
+### Task 2: Implement deleteDocument fix
+
+**Files:**
+- Modify: `lib/documents/service.ts:113-138`
+
+- [ ] **Step 1: Rewrite deleteDocument**
+
+Replace the `deleteDocument` function with:
+
+```typescript
+// 문서 삭제: URL 획득 → 원자적 소유권 검증+삭제 → Storage 정리
+export async function deleteDocument(
+  documentId: string,
+  userId: string,
+): Promise<void> {
+  // URL 획득 (소유권 확인 안 함)
+  const document = await prisma.document.findUnique({
+    where: { id: documentId },
+    select: { originalUrl: true },
+  })
+
+  // 원자적 소유권 확인 + 삭제
+  const { count } = await prisma.document.deleteMany({
+    where: { id: documentId, userId },
+  })
+
+  if (count === 0) {
+    throw new DocumentNotFoundError()
+  }
+
+  // DB 삭제 성공 후에만 Storage 정리
+  if (document?.originalUrl) {
+    await deleteFile(document.originalUrl).catch((e) =>
+      console.error("Storage 정리 실패:", e),
+    )
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run tests/lib/documents/service.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/documents/service.ts tests/lib/documents/service.test.ts
+git commit -m "fix: deleteDocument TOCTOU 패턴 수정 — deleteMany로 원자적 소유권 검증
+
+findUnique+delete 분리 패턴을 deleteMany({ id, userId })로 변경하여
+race condition 제거. Storage 삭제는 DB 삭제 성공 후에만 실행.
+403/404 통합으로 타 사용자 문서 존재 여부 비노출.
+
+Closes #87 (partial)"
+```
+
+### Task 3: Update deleteExternalDocument tests
+
+**Files:**
+- Modify: `tests/lib/external-documents/service.test.ts`
+
+- [ ] **Step 1: Update the mock setup to include deleteMany**
+
+In the prisma mock at the top of the file, add `deleteMany`:
+
+```typescript
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    externalDocument: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}))
+```
+
+- [ ] **Step 2: Rewrite deleteExternalDocument tests**
+
+Replace the entire `describe("deleteExternalDocument()")` block with:
+
+```typescript
+describe("deleteExternalDocument()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeleteFile.mockResolvedValue(undefined as never)
+    mockPrisma.externalDocument.deleteMany.mockResolvedValue({ count: 1 } as never)
+  })
+
+  it("deleteMany가 count: 0을 반환하면 ExternalDocumentNotFoundError를 던져야 한다", async () => {
+    // Arrange
+    mockPrisma.externalDocument.findUnique.mockResolvedValue({
+      originalUrl: "storage/user-1/doc.pdf",
+    } as never)
+    mockPrisma.externalDocument.deleteMany.mockResolvedValue({ count: 0 } as never)
+
+    // Act & Assert
+    await expect(deleteExternalDocument("ext-doc-999", "user-1")).rejects.toThrow(
+      ExternalDocumentNotFoundError,
+    )
+    await expect(deleteExternalDocument("ext-doc-999", "user-1")).rejects.toThrow(
+      "외부 문서를 찾을 수 없습니다.",
+    )
+  })
+
+  it("userId가 문서 소유자와 달라도 ExternalDocumentNotFoundError를 던져야 한다 (403/404 통합)", async () => {
+    // Arrange
+    mockPrisma.externalDocument.findUnique.mockResolvedValue({
+      originalUrl: "storage/owner-user/doc.pdf",
+    } as never)
+    mockPrisma.externalDocument.deleteMany.mockResolvedValue({ count: 0 } as never)
+
+    // Act & Assert
+    await expect(deleteExternalDocument("ext-doc-1", "other-user")).rejects.toThrow(
+      ExternalDocumentNotFoundError,
+    )
+    expect(mockDeleteFile).not.toHaveBeenCalled()
+  })
+
+  it("DB 삭제 후 Storage 파일을 삭제해야 한다", async () => {
+    // Arrange
+    mockPrisma.externalDocument.findUnique.mockResolvedValue({
+      originalUrl: "storage/user-1/job-posting.pdf",
+    } as never)
+    mockPrisma.externalDocument.deleteMany.mockResolvedValue({ count: 1 } as never)
+
+    // Act
+    await deleteExternalDocument("ext-doc-1", "user-1")
+
+    // Assert
+    expect(mockPrisma.externalDocument.deleteMany).toHaveBeenCalledWith({
+      where: { id: "ext-doc-1", userId: "user-1" },
+    })
+    expect(mockDeleteFile).toHaveBeenCalledWith("storage/user-1/job-posting.pdf")
+  })
+
+  it("originalUrl이 없으면 Storage 삭제를 건너뛰어야 한다", async () => {
+    // Arrange
+    mockPrisma.externalDocument.findUnique.mockResolvedValue({
+      originalUrl: null,
+    } as never)
+    mockPrisma.externalDocument.deleteMany.mockResolvedValue({ count: 1 } as never)
+
+    // Act
+    await deleteExternalDocument("ext-doc-1", "user-1")
+
+    // Assert
+    expect(mockDeleteFile).not.toHaveBeenCalled()
+    expect(mockPrisma.externalDocument.deleteMany).toHaveBeenCalledWith({
+      where: { id: "ext-doc-1", userId: "user-1" },
+    })
+  })
+
+  it("deleteFile이 실패해도 에러를 던지지 않아야 한다", async () => {
+    // Arrange
+    mockPrisma.externalDocument.findUnique.mockResolvedValue({
+      originalUrl: "storage/user-1/job-posting.pdf",
+    } as never)
+    mockPrisma.externalDocument.deleteMany.mockResolvedValue({ count: 1 } as never)
+    mockDeleteFile.mockRejectedValue(new Error("Storage 오류"))
+
+    // Act
+    await expect(deleteExternalDocument("ext-doc-1", "user-1")).resolves.toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx vitest run tests/lib/external-documents/service.test.ts`
+Expected: FAIL
+
+### Task 4: Implement deleteExternalDocument fix
+
+**Files:**
+- Modify: `lib/external-documents/service.ts:241-269`
+
+- [ ] **Step 1: Rewrite deleteExternalDocument**
+
+Replace the `deleteExternalDocument` function with:
+
+```typescript
+// 외부 문서 삭제
+export async function deleteExternalDocument(
+  documentId: string,
+  userId: string,
+): Promise<void> {
+  // URL 획득 (소유권 확인 안 함)
+  const document = await prisma.externalDocument.findUnique({
+    where: { id: documentId },
+    select: { originalUrl: true },
+  })
+
+  // 원자적 소유권 확인 + 삭제
+  const { count } = await prisma.externalDocument.deleteMany({
+    where: { id: documentId, userId },
+  })
+
+  if (count === 0) {
+    throw new ExternalDocumentNotFoundError()
+  }
+
+  // DB 삭제 성공 후에만 Storage 정리
+  if (document?.originalUrl) {
+    await deleteFile(document.originalUrl).catch((e) =>
+      console.error("Storage 정리 실패:", e),
+    )
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run tests/lib/external-documents/service.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/external-documents/service.ts tests/lib/external-documents/service.test.ts
+git commit -m "fix: deleteExternalDocument TOCTOU 패턴 수정 — deleteMany로 원자적 소유권 검증"
+```
+
+### Task 5: Update updateExternalDocument tests for $transaction
+
+**Files:**
+- Modify: `tests/lib/external-documents/service.test.ts`
+
+**Context:** `updateExternalDocument` needs a `$transaction` wrapper because it reads `sourceType` before updating. The mock must include `$transaction` that executes the callback with a transaction client.
+
+- [ ] **Step 1: Add $transaction to the prisma mock**
+
+Update the mock at the top of the file:
+
+```typescript
+vi.mock("@/lib/prisma", () => {
+  const externalDocument = {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    deleteMany: vi.fn(),
+    count: vi.fn(),
+  }
+  return {
+    prisma: {
+      externalDocument,
+      $transaction: vi.fn((fn: (tx: { externalDocument: typeof externalDocument }) => Promise<unknown>) =>
+        fn({ externalDocument }),
+      ),
+    },
+  }
+})
+```
+
+- [ ] **Step 2: Update updateExternalDocument tests for $transaction + 403/404 통합**
+
+Replace the `describe("updateExternalDocument()")` block. The key change: findUnique now uses `{ where: { id, userId } }` inside the transaction, so a non-owner gets NotFoundError instead of ForbiddenError:
+
+```typescript
+describe("updateExternalDocument()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPrisma.externalDocument.update.mockResolvedValue({
+      id: "ext-doc-1",
+      title: "수정된 제목",
+      category: "채용공고",
+      sourceType: "text",
+    } as never)
+  })
+
+  it("텍스트 문서의 제목과 내용을 수정할 수 있어야 한다", async () => {
+    // Arrange
+    mockPrisma.externalDocument.findUnique.mockResolvedValue({
+      id: "ext-doc-1",
+      userId: "user-1",
+      sourceType: "text",
+    } as never)
+
+    // Act
+    const result = await updateExternalDocument("ext-doc-1", "user-1", {
+      title: "수정된 제목",
+      content: "수정된 내용",
+    })
+
+    // Assert
+    expect(mockPrisma.externalDocument.findUnique).toHaveBeenCalledWith({
+      where: { id: "ext-doc-1", userId: "user-1" },
+      select: { id: true, sourceType: true },
+    })
+    expect(mockPrisma.externalDocument.update).toHaveBeenCalledWith({
+      where: { id: "ext-doc-1" },
+      data: { title: "수정된 제목", content: "수정된 내용" },
+      select: { id: true, title: true, category: true, sourceType: true },
+    })
+    expect(result).toMatchObject({ id: "ext-doc-1", title: "수정된 제목" })
+  })
+
+  it("파일 문서에서 content 수정 시도 시 ExternalDocumentValidationError를 던져야 한다", async () => {
+    // Arrange
+    mockPrisma.externalDocument.findUnique.mockResolvedValue({
+      id: "ext-doc-2",
+      userId: "user-1",
+      sourceType: "file",
+    } as never)
+
+    // Act & Assert
+    await expect(
+      updateExternalDocument("ext-doc-2", "user-1", { content: "수정 시도" }),
+    ).rejects.toThrow(ExternalDocumentValidationError)
+    await expect(
+      updateExternalDocument("ext-doc-2", "user-1", { content: "수정 시도" }),
+    ).rejects.toThrow("파일 문서의 내용은 수정할 수 없습니다.")
+  })
+
+  it("문서가 존재하지 않으면 ExternalDocumentNotFoundError를 던져야 한다", async () => {
+    // Arrange
+    mockPrisma.externalDocument.findUnique.mockResolvedValue(null)
+
+    // Act & Assert
+    await expect(
+      updateExternalDocument("ext-doc-999", "user-1", { title: "수정" }),
+    ).rejects.toThrow(ExternalDocumentNotFoundError)
+  })
+
+  it("소유자가 다르면 ExternalDocumentNotFoundError를 던져야 한다 (403/404 통합)", async () => {
+    // Arrange — where: { id, userId } 불일치로 null 반환
+    mockPrisma.externalDocument.findUnique.mockResolvedValue(null)
+
+    // Act & Assert
+    await expect(
+      updateExternalDocument("ext-doc-1", "other-user", { title: "수정" }),
+    ).rejects.toThrow(ExternalDocumentNotFoundError)
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx vitest run tests/lib/external-documents/service.test.ts`
+Expected: FAIL — updateExternalDocument still uses old pattern without $transaction
+
+### Task 6: Implement updateExternalDocument fix
+
+**Files:**
+- Modify: `lib/external-documents/service.ts:203-239`
+
+- [ ] **Step 1: Rewrite updateExternalDocument**
+
+Replace the `updateExternalDocument` function with:
+
+```typescript
+// 외부 문서 수정
+export async function updateExternalDocument(
+  documentId: string,
+  userId: string,
+  data: { title?: string; category?: string; content?: string },
+) {
+  return prisma.$transaction(async (tx) => {
+    const document = await tx.externalDocument.findUnique({
+      where: { id: documentId, userId },
+      select: { id: true, sourceType: true },
+    })
+
+    if (!document) {
+      throw new ExternalDocumentNotFoundError()
+    }
+
+    // 파일 문서에서 content 수정 시도 차단
+    if (document.sourceType === "file" && data.content !== undefined) {
+      throw new ExternalDocumentValidationError(
+        "파일 문서의 내용은 수정할 수 없습니다.",
+      )
+    }
+
+    const updateData: Record<string, string> = {}
+    if (data.title !== undefined) updateData.title = data.title
+    if (data.category !== undefined) updateData.category = data.category
+    if (data.content !== undefined) updateData.content = data.content
+
+    return tx.externalDocument.update({
+      where: { id: documentId },
+      data: updateData,
+      select: { id: true, title: true, category: true, sourceType: true },
+    })
+  })
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run tests/lib/external-documents/service.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 3: Remove unused error classes**
+
+In `lib/documents/service.ts`, remove `DocumentForbiddenError` (no longer thrown).
+In `lib/external-documents/service.ts`, remove `ExternalDocumentForbiddenError` (no longer thrown).
+
+Check for usages first:
+
+Run: `grep -r "DocumentForbiddenError\|ExternalDocumentForbiddenError" --include="*.ts" --include="*.tsx" lib/ app/ tests/ components/`
+
+Remove from source files and test imports if no other references exist. If there are references in API route handlers, update them accordingly.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `npx vitest run tests/lib/documents/service.test.ts tests/lib/external-documents/service.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/external-documents/service.ts lib/documents/service.ts tests/lib/external-documents/service.test.ts tests/lib/documents/service.test.ts
+git commit -m "fix: updateExternalDocument $transaction 래핑 + unused ForbiddenError 제거
+
+Closes #87"
+```
+
+---
+
+## PR 2: Admin 영역 통합 개선 (#63, #64, #61)
+
+Branch: `refactor/admin-improvements`
+
+### Task 7: Extract shared admin types (#64 타입 중복)
+
+**Files:**
+- Create: `types/admin.ts`
+- Modify: `components/admin/quota-table.tsx:33-41`
+- Modify: `components/admin/pricing-table.tsx:33-40`
+- Modify: `app/(dashboard)/admin/quotas/page.tsx:6-14`
+- Modify: `app/(dashboard)/admin/model-pricing/page.tsx:6-13`
+
+- [ ] **Step 1: Create types/admin.ts**
+
+```typescript
+export interface QuotaEntry {
+  id: string
+  userId: string
+  limitType: string
+  limitValue: number
+  period: string
+  isActive: boolean
+  user: { email: string; name: string | null }
+}
+
+export interface PricingEntry {
+  id: string
+  provider: string
+  model: string
+  inputPricePerM: number
+  outputPricePerM: number
+  effectiveFrom: string
+}
+```
+
+- [ ] **Step 2: Replace inline interfaces in all 4 files**
+
+In `components/admin/quota-table.tsx`, remove the `QuotaEntry` interface (lines 33-41) and add import:
+```typescript
+import type { QuotaEntry } from "@/types/admin"
+```
+
+In `components/admin/pricing-table.tsx`, remove the `PricingEntry` interface (lines 33-40) and add import:
+```typescript
+import type { PricingEntry } from "@/types/admin"
+```
+
+In `app/(dashboard)/admin/quotas/page.tsx`, remove the `QuotaEntry` interface (lines 6-14) and add import:
+```typescript
+import type { QuotaEntry } from "@/types/admin"
+```
+
+In `app/(dashboard)/admin/model-pricing/page.tsx`, remove the `PricingEntry` interface (lines 6-13) and add import:
+```typescript
+import type { PricingEntry } from "@/types/admin"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add types/admin.ts components/admin/quota-table.tsx components/admin/pricing-table.tsx app/\(dashboard\)/admin/quotas/page.tsx app/\(dashboard\)/admin/model-pricing/page.tsx
+git commit -m "refactor: PricingEntry, QuotaEntry를 types/admin.ts로 추출하여 중복 제거"
+```
+
+### Task 8: Fix UserInfo.role type (#64)
+
+**Files:**
+- Modify: `lib/supabase/user.ts:5-10`
+
+- [ ] **Step 1: Change role type**
+
+In `lib/supabase/user.ts`, change line 9:
+
+```typescript
+// Before
+role?: string
+
+// After
+role?: "ADMIN" | "USER"
+```
+
+- [ ] **Step 2: Check for type errors propagated by this change**
+
+Run: `npx tsc --noEmit 2>&1 | head -30`
+
+If type errors appear in files that assign a plain `string` to `role`, update those call sites. The main call site is `app/(dashboard)/layout.tsx:23`:
+
+```typescript
+// Before
+const userInfo = { ...extractUserInfo(user), role: dbUser?.role ?? "USER" }
+
+// After — dbUser.role is already string from Prisma, needs assertion
+const userInfo = { ...extractUserInfo(user), role: (dbUser?.role ?? "USER") as "ADMIN" | "USER" }
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/supabase/user.ts app/\(dashboard\)/layout.tsx
+git commit -m "refactor: UserInfo.role을 'ADMIN' | 'USER' 리터럴 타입으로 변경"
+```
+
+### Task 9: Fix alert → toast in quota-table (#64)
+
+**Files:**
+- Modify: `components/admin/quota-table.tsx:108`
+
+- [ ] **Step 1: Add toast import and replace alert**
+
+Add import at the top of `components/admin/quota-table.tsx`:
+
+```typescript
+import { toast } from "sonner"
+```
+
+Replace line 108:
+
+```typescript
+// Before
+alert(err instanceof Error ? err.message : "삭제에 실패했습니다.")
+
+// After
+toast.error(err instanceof Error ? err.message : "삭제에 실패했습니다.")
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/admin/quota-table.tsx
+git commit -m "fix: quota 삭제 실패 시 alert() → toast.error()로 교체"
+```
+
+### Task 10: Fix Dialog reset in pricing-table (#64)
+
+**Files:**
+- Modify: `components/admin/pricing-table.tsx`
+
+**Context:** The form is uncontrolled (uses `FormData`). When the dialog closes and reopens, previous input values persist in the DOM. Using a `key` prop that changes when `open` changes forces React to remount the DialogContent, resetting all form fields.
+
+- [ ] **Step 1: Add key prop to force remount on reopen**
+
+In `components/admin/pricing-table.tsx`, add `key` to the `DialogContent` component (around line 96):
+
+```tsx
+// Before
+<DialogContent>
+
+// After
+<DialogContent key={String(open)}>
+```
+
+Also reset the `error` state when dialog opens. In the `onOpenChange` handler, update the Dialog:
+
+```tsx
+// Before
+<Dialog open={open} onOpenChange={setOpen}>
+
+// After
+<Dialog open={open} onOpenChange={(v) => { setOpen(v); setError(""); }}>
+```
+
+- [ ] **Step 2: Apply the same fix to quota-table create dialog**
+
+In `components/admin/quota-table.tsx`, apply the same pattern to the create dialog (around line 118):
+
+```tsx
+// Before
+<Dialog open={open} onOpenChange={setOpen}>
+
+// After
+<Dialog open={open} onOpenChange={(v) => { setOpen(v); setError(""); }}>
+```
+
+Add `key` to the `DialogContent` (around line 125):
+
+```tsx
+// Before
+<DialogContent>
+
+// After
+<DialogContent key={String(open)}>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/admin/pricing-table.tsx components/admin/quota-table.tsx
+git commit -m "fix: admin Dialog 재열기 시 이전 입력값/에러 잔류 수정 — key prop으로 DOM 리셋"
+```
+
+### Task 11: Create getUserRole with React.cache (#63)
+
+**Files:**
+- Create: `lib/auth/get-user-role.ts`
+- Modify: `app/(dashboard)/layout.tsx`
+- Modify: `lib/auth/require-admin.ts`
+
+- [ ] **Step 1: Create lib/auth/get-user-role.ts**
+
+```typescript
+import { cache } from "react"
+import { prisma } from "@/lib/prisma"
+
+/**
+ * React.cache()로 래핑된 user role 조회.
+ * 같은 RSC 렌더 패스 내에서 여러 번 호출해도 실제 DB 쿼리는 1회만 실행.
+ */
+export const getUserRole = cache(async (userId: string): Promise<"ADMIN" | "USER"> => {
+  const dbUser = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true },
+  })
+  return (dbUser?.role ?? "USER") as "ADMIN" | "USER"
+})
+```
+
+- [ ] **Step 2: Update app/(dashboard)/layout.tsx**
+
+```typescript
+// Remove prisma import, add getUserRole import
+import { getUserRole } from "@/lib/auth/get-user-role"
+
+// Replace lines 19-23:
+// Before
+const dbUser = await prisma.user.findUnique({
+  where: { id: user.id },
+  select: { role: true },
+})
+const userInfo = { ...extractUserInfo(user), role: dbUser?.role ?? "USER" }
+
+// After
+const role = await getUserRole(user.id)
+const userInfo = { ...extractUserInfo(user), role }
+```
+
+Also remove `import { prisma } from "@/lib/prisma"` since it's no longer used directly.
+
+- [ ] **Step 3: Update lib/auth/require-admin.ts**
+
+```typescript
+import { createClient } from "@/lib/supabase/server"
+import { getUserRole } from "@/lib/auth/get-user-role"
+
+type AdminResult =
+  | { ok: true; user: { id: string; role: string } }
+  | { ok: false; status: 401 }
+  | { ok: false; status: 403 }
+
+export async function requireAdmin(): Promise<AdminResult> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) return { ok: false, status: 401 }
+
+  const role = await getUserRole(user.id)
+
+  if (role !== "ADMIN") return { ok: false, status: 403 }
+
+  return { ok: true, user: { id: user.id, role } }
+}
+```
+
+- [ ] **Step 4: Update require-admin.test.ts mock**
+
+In `tests/lib/auth/require-admin.test.ts`, replace the prisma mock with a getUserRole mock:
+
+```typescript
+// Replace prisma mock with:
+vi.mock("@/lib/auth/get-user-role", () => ({
+  getUserRole: vi.fn(),
+}))
+
+import { getUserRole } from "@/lib/auth/get-user-role"
+const mockGetUserRole = vi.mocked(getUserRole)
+```
+
+Update test arrangements to use `mockGetUserRole.mockResolvedValue("ADMIN")` / `mockGetUserRole.mockResolvedValue("USER")` instead of `mockPrisma.user.findUnique(...)`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run tests/lib/auth/require-admin.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/auth/get-user-role.ts app/\(dashboard\)/layout.tsx lib/auth/require-admin.ts tests/lib/auth/require-admin.test.ts
+git commit -m "perf: React.cache()로 user role 조회 중복 제거
+
+layout.tsx와 requireAdmin()이 동일 user를 각각 조회하던 것을
+getUserRole()으로 통합. RSC 렌더 내 한 번만 DB 쿼리.
+
+Closes #63"
+```
+
+### Task 12: Add Quota edit dialog (#61)
+
+**Files:**
+- Modify: `components/admin/quota-table.tsx`
+
+**Context:** The existing create dialog uses uncontrolled form with `FormData`. The edit dialog follows the same pattern. The PUT `/api/admin/quotas/[id]` API accepts `{ limitValue?, isActive? }`.
+
+- [ ] **Step 1: Add edit dialog state and handler**
+
+In `components/admin/quota-table.tsx`, add state and handler inside the `QuotaTable` component, after the existing state declarations:
+
+```typescript
+import { Pencil, Plus, Trash2 } from "lucide-react"
+import { Switch } from "@/components/ui/switch"
+
+// Inside QuotaTable component, after existing state:
+const [editTarget, setEditTarget] = useState<QuotaEntry | null>(null)
+const [editSubmitting, setEditSubmitting] = useState(false)
+const [editError, setEditError] = useState("")
+
+async function handleEdit(e: React.FormEvent<HTMLFormElement>) {
+  e.preventDefault()
+  if (!editTarget) return
+  setEditSubmitting(true)
+  setEditError("")
+
+  const form = new FormData(e.currentTarget)
+  const body = {
+    limitValue: Number(form.get("limitValue")),
+    isActive: form.get("isActive") === "on",
+  }
+
+  try {
+    const res = await fetch(`/api/admin/quotas/${editTarget.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      const data = await res.json()
+      throw new Error(data.error ?? "수정에 실패했습니다.")
+    }
+    setEditTarget(null)
+    onChanged()
+  } catch (err) {
+    setEditError(err instanceof Error ? err.message : "오류가 발생했습니다.")
+  } finally {
+    setEditSubmitting(false)
+  }
+}
+```
+
+- [ ] **Step 2: Add edit button to table rows**
+
+In the table row actions cell (around line 233), add an edit button before the delete button:
+
+```tsx
+<TableCell className="flex gap-1">
+  <Button
+    variant="ghost"
+    size="icon"
+    onClick={() => setEditTarget(quota)}
+  >
+    <Pencil className="h-4 w-4" />
+  </Button>
+  <Button
+    variant="ghost"
+    size="icon"
+    disabled={deletingId === quota.id}
+    onClick={() => handleDelete(quota.id)}
+  >
+    <Trash2 className="h-4 w-4" />
+  </Button>
+</TableCell>
+```
+
+Update the `<TableHead className="w-16" />` to `<TableHead className="w-24" />` to accommodate two buttons.
+
+- [ ] **Step 3: Add edit dialog JSX**
+
+Add the edit dialog after the Card's closing tag, but before the component's return closes. Or add it inside the Card, after `</CardContent>`:
+
+```tsx
+<Dialog open={editTarget !== null} onOpenChange={(v) => { if (!v) { setEditTarget(null); setEditError(""); } }}>
+  <DialogContent key={editTarget?.id}>
+    <DialogHeader>
+      <DialogTitle>Quota 수정</DialogTitle>
+      <DialogDescription>
+        {editTarget?.user.email} — {LIMIT_LABELS[editTarget?.limitType ?? ""] ?? editTarget?.limitType} ({PERIOD_LABELS[editTarget?.period ?? ""] ?? editTarget?.period})
+      </DialogDescription>
+    </DialogHeader>
+    <form onSubmit={handleEdit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="edit-limitValue">제한 값</Label>
+        <Input
+          id="edit-limitValue"
+          name="limitValue"
+          type="number"
+          min="1"
+          required
+          defaultValue={editTarget?.limitValue}
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch
+          id="edit-isActive"
+          name="isActive"
+          defaultChecked={editTarget?.isActive}
+        />
+        <Label htmlFor="edit-isActive">활성</Label>
+      </div>
+      {editError && (
+        <p className="text-sm text-destructive">{editError}</p>
+      )}
+      <Button type="submit" disabled={editSubmitting} className="w-full">
+        {editSubmitting ? "수정 중..." : "수정"}
+      </Button>
+    </form>
+  </DialogContent>
+</Dialog>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/admin/quota-table.tsx
+git commit -m "feat: admin quota 수정 Dialog 추가 — limitValue, isActive 편집
+
+기존 PUT /api/admin/quotas/[id] API 활용.
+생성 Dialog 패턴(uncontrolled FormData)을 그대로 따름.
+
+Closes #61
+Closes #64"
+```
+
+---
+
+## PR 3: Skeleton Fallback 일관성 (#40)
+
+Branch: `fix/skeleton-fallback-consistency`
+
+### Task 13: Replace text fallback with Skeleton in resumes page
+
+**Files:**
+- Modify: `app/(dashboard)/resumes/page.tsx:44`
+
+**Context:** The existing `loading.tsx` renders a full-page skeleton including header + grid. The Suspense fallback only needs the list area skeleton (the header is already rendered outside Suspense). Extract just the list grid skeleton.
+
+- [ ] **Step 1: Replace text fallback with Skeleton**
+
+In `app/(dashboard)/resumes/page.tsx`, add Skeleton import and replace the Suspense fallback:
+
+```typescript
+import { Skeleton } from "@/components/ui/skeleton"
+```
+
+Replace line 44:
+
+```tsx
+// Before
+<Suspense fallback={<p className="text-muted-foreground py-12 text-center">불러오는 중...</p>}>
+
+// After
+<Suspense
+  fallback={
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }, (_, i) => (
+        <div key={i} className="space-y-3 rounded-xl border p-6">
+          <div className="flex items-start justify-between">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-5 w-5" />
+              <Skeleton className="h-5 w-32" />
+            </div>
+            <Skeleton className="h-8 w-8 rounded-md" />
+          </div>
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      ))}
+    </div>
+  }
+>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/\(dashboard\)/resumes/page.tsx
+git commit -m "fix: resumes 페이지 Suspense fallback을 Skeleton으로 교체"
+```
+
+### Task 14: Replace text fallback with Skeleton in insights page
+
+**Files:**
+- Modify: `app/(dashboard)/insights/page.tsx:56-61`
+
+- [ ] **Step 1: Replace text fallback with Skeleton**
+
+Add Skeleton import:
+
+```typescript
+import { Skeleton } from "@/components/ui/skeleton"
+```
+
+Replace the Suspense fallback:
+
+```tsx
+// Before
+<Suspense
+  fallback={
+    <p className="text-muted-foreground py-12 text-center">
+      불러오는 중...
+    </p>
+  }
+>
+
+// After
+<Suspense
+  fallback={
+    <div className="space-y-6">
+      <div className="flex gap-2">
+        {Array.from({ length: 5 }, (_, i) => (
+          <Skeleton key={i} className="h-9 w-20 rounded-md" />
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }, (_, i) => (
+          <div key={i} className="space-y-3 rounded-xl border p-6">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="h-4 w-12" />
+            </div>
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+        ))}
+      </div>
+    </div>
+  }
+>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/\(dashboard\)/insights/page.tsx
+git commit -m "fix: insights 페이지 Suspense fallback을 Skeleton으로 교체"
+```
+
+### Task 15: Add Skeleton fallback to login page
+
+**Files:**
+- Modify: `app/(auth)/login/page.tsx:84-89`
+
+- [ ] **Step 1: Add Skeleton import and fallback**
+
+Add import:
+
+```typescript
+import { Skeleton } from "@/components/ui/skeleton"
+```
+
+Replace the Suspense wrapper:
+
+```tsx
+// Before
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
+  )
+}
+
+// After
+export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-svh items-center justify-center">
+          <div className="flex w-full max-w-sm flex-col items-center gap-8 px-4">
+            <div className="text-center space-y-2">
+              <Skeleton className="mx-auto h-8 w-48" />
+              <Skeleton className="mx-auto h-5 w-56" />
+            </div>
+            <div className="flex w-full flex-col gap-3">
+              <Skeleton className="h-12 w-full rounded-md" />
+              <Skeleton className="h-12 w-full rounded-md" />
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <LoginContent />
+    </Suspense>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/\(auth\)/login/page.tsx
+git commit -m "fix: login 페이지 Suspense에 Skeleton fallback 추가
+
+Closes #40"
+```

--- a/docs/superpowers/specs/2026-03-26-ai-infra-doc-rewrite-design.md
+++ b/docs/superpowers/specs/2026-03-26-ai-infra-doc-rewrite-design.md
@@ -1,0 +1,69 @@
+# AI 인프라 문서 재작성 설계
+
+> 2026-03-26
+
+## 목적
+
+`docs/features/05-ai-infra.md`를 현재 코드에 맞게 재작성한다. 삭제된 tool use, multi-step/classification 파이프라인 분기 내용을 제거하고, 현행 단일 파이프라인 흐름을 중심으로 정리한다.
+
+## 배경
+
+PR #93(deterministic-routing 벤치마크 + 파이프라인 단순화)에서 채팅 파이프라인이 대폭 변경됨:
+
+- tool use 4개 도구 (`readDocument`, `readExternalDocument`, `readCareerNote`, `saveCareerNote`) 삭제
+- provider별 파이프라인 분기 (`selectPipeline`, `multi-step`, `classification`) 삭제
+- 단일 파이프라인으로 통합: 문서 전문 주입 → 압축 → streamText
+
+현재 `05-ai-infra.md`에는 삭제된 내용이 그대로 남아 있어 코드와 괴리 상당.
+
+## 문서 구조
+
+파이프라인 흐름 중심(요청 → 응답 순서)으로 구성한다.
+
+### 섹션 구성
+
+```
+# AI 인프라 — 채팅 파이프라인
+
+## 개요
+## 파이프라인 흐름도 (Mermaid)
+## 단계별 상세
+  ### 1. 인증 & 요청 검증
+  ### 2. 쿼터 체크
+  ### 3. 컨텍스트 빌드 + 모델 로딩 (병렬)
+  ### 4. 시스템 프롬프트
+  ### 5. 대화 압축
+  ### 6. 스트리밍 응답 & 후처리
+## 지원 모델
+## 주요 파일 맵
+```
+
+### 각 섹션 내용
+
+**개요**: 한 줄 요약 + 변경 배경 (tool-calling → classification → 전문 주입으로의 진화)
+
+**파이프라인 흐름도**: Mermaid flowchart. 인증 → 검증 → 소유권확인 → 쿼터 → [컨텍스트빌드 || 모델로딩] → 시스템프롬프트 → 압축판단 → streamText → onFinish(DB+토큰)
+
+**단계별 상세**:
+1. 인증 & 검증 — Supabase auth, Zod 스키마(`coverLetterChatSchema`/`interviewChatSchema`), 소유권 체크. cover-letter vs interview 차이(외부문서 조회 경로, 커리어노트 포함 여부)
+2. 쿼터 — `checkQuotaExceeded`: TOKENS/COST/REQUESTS × DAILY/MONTHLY
+3. 컨텍스트 + 모델 — `buildFullContext`(문서 전문 + 외부 문서 + 커리어노트), `getLanguageModel`(DB → factory). `Promise.all`로 병렬
+4. 시스템 프롬프트 — `buildCoverLetterSystemPrompt` / `buildInterviewSystemPrompt` 파라미터 설명
+5. 압축 — `compressIfNeeded`: 토큰 > contextWindow × 50% 시 이전 대화 LLM 요약, 최근 4턴 유지
+6. 응답 + 후처리 — `streamText` (tools 없음), `onFinish`에서 메시지 DB 저장 + `recordUsage` + 비용 계산(`ModelPricing`)
+
+**지원 모델**: `types/ai.ts`의 `PROVIDER_MODELS` 테이블
+
+**주요 파일 맵**: 파일 경로 ↔ 역할 테이블
+
+### 의도적 제외
+
+- 삭제된 tool use, multi-step, classification, selectPipeline 관련 내용
+- 벤치마크 인프라 (별도 문서 영역)
+- 채팅 UI 컴포넌트
+- 설정 페이지 / API key 관리
+
+## 작업 범위
+
+- `docs/features/05-ai-infra.md` 전체 재작성 (기존 내용 대체)
+- 새 파일 생성 없음

--- a/docs/superpowers/specs/2026-03-26-bugfix-batch-design.md
+++ b/docs/superpowers/specs/2026-03-26-bugfix-batch-design.md
@@ -1,0 +1,139 @@
+# Bugfix Batch — 5개 이슈 수정 설계
+
+> 대상 이슈: #87, #63, #64, #61, #40
+> 작성일: 2026-03-26
+
+---
+
+## PR 구성
+
+| PR | 이슈 | 브랜치명 | 요약 |
+|----|------|----------|------|
+| PR 1 | #87 | fix/toctou-document-service | TOCTOU 패턴 수정 |
+| PR 2 | #63 #64 #61 | refactor/admin-improvements | Admin 영역 통합 개선 |
+| PR 3 | #40 | fix/skeleton-fallback-consistency | Skeleton fallback 일관성 |
+
+---
+
+## PR 1: TOCTOU Pattern Fix (#87)
+
+### 문제
+
+`findUnique`로 소유권 확인 후 별도 `update`/`delete` 호출하는 TOCTOU 패턴.
+두 쿼리 사이에 문서가 삭제되면 Prisma P2025 에러가 500으로 노출됨.
+
+### 대상 파일
+
+- `lib/documents/service.ts` — `deleteDocument`
+- `lib/external-documents/service.ts` — `updateExternalDocument`, `deleteExternalDocument`
+
+### 설계
+
+#### deleteDocument, deleteExternalDocument
+
+순서를 변경하여 원자적 소유권 확인 + 삭제를 수행한다.
+
+```
+findUnique({ where: { id } })       → URL 획득 (소유권 확인 안 함)
+delete({ where: { id, userId } })   → 소유권 확인 + 삭제 원자적
+  성공 → storage 삭제
+  P2025 → NotFoundError throw
+```
+
+핵심 변경:
+- `where` 조건에 `userId`를 포함하여 단일 쿼리로 소유권 확인과 삭제를 동시 수행
+- storage 삭제는 DB 삭제 성공 후에만 실행 (타 사용자 파일 삭제 방지)
+- 403/404 통합: "문서가 없음"과 "다른 사용자의 문서" 모두 NotFoundError로 처리 (타 사용자 문서 존재 여부 비노출 — 보안 이점)
+
+#### updateExternalDocument
+
+`source` 필드 검증 등 비즈니스 로직이 findUnique 결과에 의존하므로
+`$transaction`으로 findUnique + update를 래핑한다.
+
+```typescript
+await prisma.$transaction(async (tx) => {
+  const doc = await tx.externalDocument.findUnique({ where: { id, userId } })
+  if (!doc) throw new ExternalDocumentNotFoundError()
+  // source 검증 등 비즈니스 로직
+  return tx.externalDocument.update({ where: { id }, data: { ... } })
+})
+```
+
+delete와 동일하게 `where: { id, userId }`로 조회하므로 403/404 통합 정책 적용.
+"문서가 없음"과 "다른 사용자의 문서" 모두 NotFoundError로 처리.
+
+---
+
+## PR 2: Admin 영역 통합 개선 (#63, #64, #61)
+
+### #63 — user 쿼리 중복 제거
+
+#### 문제
+
+`app/(dashboard)/layout.tsx`에서 `prisma.user.findUnique`로 role을 조회하고,
+`/admin/*` 경로에서 `requireAdmin()`이 동일 user를 재조회. RSC 렌더 내 요청당 2회 쿼리.
+
+#### 설계
+
+`React.cache()`로 user role 조회 함수를 래핑한다.
+
+```typescript
+// lib/auth/get-user-role.ts (신규)
+import { cache } from "react"
+
+export const getUserRole = cache(async (userId: string) => {
+  const dbUser = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true },
+  })
+  return dbUser?.role ?? "USER"
+})
+```
+
+- `layout.tsx`와 `requireAdmin()` 양쪽에서 `getUserRole()` 호출
+- `React.cache()`는 RSC 렌더 패스 내에서만 중복 제거 — API route handler에서의 호출은 별도 요청이므로 영향 없음
+
+### #64 — Admin UI 4가지 개선
+
+| 항목 | 파일 | 수정 내용 |
+|------|------|----------|
+| alert→toast | `components/admin/quota-table.tsx` | 삭제 실패 시 `alert()` → `toast.error()` |
+| dialog reset | `components/admin/pricing-table.tsx` | uncontrolled form이므로 Dialog에 `key` prop 사용하여 닫힐 때 DOM 리셋 |
+| 타입 중복 | `types/admin.ts` (신규) | `PricingEntry`, `QuotaEntry` 추출. 4개 파일에서 import로 교체 |
+| UserInfo.role | 해당 타입 정의 위치 | `role?: string` → `role: "ADMIN" \| "USER"` 리터럴 타입 |
+
+타입 중복 현황:
+- `PricingEntry`: `pricing-table.tsx` + `admin/model-pricing/page.tsx` (동일 정의 2곳)
+- `QuotaEntry`: `quota-table.tsx` + `admin/quotas/page.tsx` (동일 정의 2곳)
+
+### #61 — Quota 수정 Dialog
+
+#### 설계
+
+`quota-table.tsx`에 편집 Dialog를 추가한다.
+
+- 기존 생성 Dialog 패턴(uncontrolled FormData)을 그대로 따름
+- 수정 가능 필드: `limitValue`, `isActive`
+- 기존 PUT `/api/admin/quotas/[id]` API 활용
+- 테이블 행에 편집 버튼 추가 → Dialog 열기 → 기존 값 prefill → PUT 요청
+
+---
+
+## PR 3: Skeleton Fallback 일관성 (#40)
+
+### 문제
+
+일부 페이지에서 `<Suspense>` fallback이 텍스트(`불러오는 중...`)이거나 누락됨.
+
+### 대상 파일 및 수정
+
+| 파일 | 현재 | 수정 |
+|------|------|------|
+| `app/(dashboard)/resumes/page.tsx` | `<p>불러오는 중...</p>` | 해당 페이지 `loading.tsx`의 Skeleton 재사용 |
+| `app/(dashboard)/insights/page.tsx` | `<p>불러오는 중...</p>` | 동일 |
+| `app/(auth)/login/page.tsx` | `<Suspense>` (fallback 없음) | 로그인 폼 영역 크기의 Skeleton fallback 추가 |
+
+### 범위 제한
+
+- `loading.tsx`↔Suspense 간 역할 분리(깜빡임 방지)는 이번 범위에서 제외
+- 텍스트 fallback → Skeleton 교체 + 누락 fallback 추가만 수행

--- a/lib/auth/get-user-role.ts
+++ b/lib/auth/get-user-role.ts
@@ -3,12 +3,13 @@ import { prisma } from "@/lib/prisma"
 
 /**
  * React.cache()로 래핑된 user role 조회.
- * 같은 RSC 렌더 패스 내에서 여러 번 호출해도 실제 DB 쿼리는 1회만 실행.
+ * RSC 렌더 패스 내에서 여러 번 호출해도 실제 DB 쿼리는 1회만 실행.
+ * API route handler에서는 cache가 적용되지 않으나 정상 동작.
  */
 export const getUserRole = cache(async (userId: string): Promise<"ADMIN" | "USER"> => {
   const dbUser = await prisma.user.findUnique({
     where: { id: userId },
     select: { role: true },
   })
-  return (dbUser?.role ?? "USER") as "ADMIN" | "USER"
+  return dbUser?.role === "ADMIN" ? "ADMIN" : "USER"
 })

--- a/lib/auth/get-user-role.ts
+++ b/lib/auth/get-user-role.ts
@@ -1,0 +1,14 @@
+import { cache } from "react"
+import { prisma } from "@/lib/prisma"
+
+/**
+ * React.cache()로 래핑된 user role 조회.
+ * 같은 RSC 렌더 패스 내에서 여러 번 호출해도 실제 DB 쿼리는 1회만 실행.
+ */
+export const getUserRole = cache(async (userId: string): Promise<"ADMIN" | "USER"> => {
+  const dbUser = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true },
+  })
+  return (dbUser?.role ?? "USER") as "ADMIN" | "USER"
+})

--- a/lib/auth/get-user-role.ts
+++ b/lib/auth/get-user-role.ts
@@ -4,7 +4,8 @@ import { prisma } from "@/lib/prisma"
 /**
  * React.cache()로 래핑된 user role 조회.
  * RSC 렌더 패스 내에서 여러 번 호출해도 실제 DB 쿼리는 1회만 실행.
- * API route handler에서는 cache가 적용되지 않으나 정상 동작.
+ * API route handler에서는 요청마다 새로운 cache scope가 생성되므로
+ * 동일 요청 내 중복 제거(deduplication)가 적용되지 않으나 정상 동작.
  */
 export const getUserRole = cache(async (userId: string): Promise<"ADMIN" | "USER"> => {
   const dbUser = await prisma.user.findUnique({

--- a/lib/auth/require-admin.ts
+++ b/lib/auth/require-admin.ts
@@ -2,7 +2,7 @@ import { createClient } from "@/lib/supabase/server"
 import { getUserRole } from "@/lib/auth/get-user-role"
 
 type AdminResult =
-  | { ok: true; user: { id: string; role: string } }
+  | { ok: true; user: { id: string; role: "ADMIN" } }
   | { ok: false; status: 401 }
   | { ok: false; status: 403 }
 

--- a/lib/auth/require-admin.ts
+++ b/lib/auth/require-admin.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server"
-import { prisma } from "@/lib/prisma"
+import { getUserRole } from "@/lib/auth/get-user-role"
 
 type AdminResult =
   | { ok: true; user: { id: string; role: string } }
@@ -12,12 +12,9 @@ export async function requireAdmin(): Promise<AdminResult> {
 
   if (!user) return { ok: false, status: 401 }
 
-  const dbUser = await prisma.user.findUnique({
-    where: { id: user.id },
-    select: { id: true, role: true },
-  })
+  const role = await getUserRole(user.id)
 
-  if (!dbUser || dbUser.role !== "ADMIN") return { ok: false, status: 403 }
+  if (role !== "ADMIN") return { ok: false, status: 403 }
 
-  return { ok: true, user: dbUser }
+  return { ok: true, user: { id: user.id, role } }
 }

--- a/lib/supabase/user.ts
+++ b/lib/supabase/user.ts
@@ -6,7 +6,7 @@ export interface UserInfo {
   name: string | null
   email: string | null
   avatarUrl: string | null
-  role?: string
+  role?: "ADMIN" | "USER"
 }
 
 export function extractUserInfo(user: User): UserInfo {

--- a/tests/lib/auth/require-admin.test.ts
+++ b/tests/lib/auth/require-admin.test.ts
@@ -4,18 +4,16 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }))
 
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    user: { findUnique: vi.fn() },
-  },
+vi.mock("@/lib/auth/get-user-role", () => ({
+  getUserRole: vi.fn(),
 }))
 
 import { createClient } from "@/lib/supabase/server"
-import { prisma } from "@/lib/prisma"
+import { getUserRole } from "@/lib/auth/get-user-role"
 import { requireAdmin } from "@/lib/auth/require-admin"
 
 const mockCreateClient = vi.mocked(createClient)
-const mockFindUnique = vi.mocked(prisma.user.findUnique)
+const mockGetUserRole = vi.mocked(getUserRole)
 
 describe("requireAdmin", () => {
   beforeEach(() => { vi.clearAllMocks() })
@@ -32,7 +30,7 @@ describe("requireAdmin", () => {
     mockCreateClient.mockResolvedValue({
       auth: { getUser: () => Promise.resolve({ data: { user: { id: "u1" } }, error: null }) },
     } as unknown as Awaited<ReturnType<typeof mockCreateClient>>)
-    mockFindUnique.mockResolvedValue({ id: "u1", role: "ADMIN" } as unknown as Awaited<ReturnType<typeof mockFindUnique>>)
+    mockGetUserRole.mockResolvedValue("ADMIN")
     const result = await requireAdmin()
     expect(result).toEqual({ ok: true, user: { id: "u1", role: "ADMIN" } })
   })
@@ -41,7 +39,7 @@ describe("requireAdmin", () => {
     mockCreateClient.mockResolvedValue({
       auth: { getUser: () => Promise.resolve({ data: { user: { id: "u1" } }, error: null }) },
     } as unknown as Awaited<ReturnType<typeof mockCreateClient>>)
-    mockFindUnique.mockResolvedValue({ id: "u1", role: "USER" } as unknown as Awaited<ReturnType<typeof mockFindUnique>>)
+    mockGetUserRole.mockResolvedValue("USER")
     const result = await requireAdmin()
     expect(result).toEqual({ ok: false, status: 403 })
   })

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -1,0 +1,18 @@
+export interface QuotaEntry {
+  id: string
+  userId: string
+  limitType: string
+  limitValue: number
+  period: string
+  isActive: boolean
+  user: { email: string; name: string | null }
+}
+
+export interface PricingEntry {
+  id: string
+  provider: string
+  model: string
+  inputPricePerM: number
+  outputPricePerM: number
+  effectiveFrom: string
+}


### PR DESCRIPTION
## Summary
- **#63 쿼리 중복 제거**: `React.cache()`로 `getUserRole()` 래핑 — layout.tsx와 requireAdmin()의 user role 조회 통합
- **#64 Admin UI 개선**:
  - quota 삭제 실패 시 `alert()` → `toast.error()`
  - Dialog 재열기 시 이전 입력값/에러 잔류 수정 (key prop + error reset)
  - `PricingEntry`, `QuotaEntry`를 `types/admin.ts`로 추출하여 4개 파일 중복 제거
  - `UserInfo.role`을 `"ADMIN" | "USER"` 리터럴 타입으로 변경
- **#61 Quota 수정 Dialog**: limitValue, isActive 편집 가능한 Dialog 추가 (기존 PUT API 활용)
- **리뷰 반영**: Switch 컴포넌트 생성, isActive controlled state 전환, editKey로 stale form 방지, getUserRole `as` cast 제거

## Related Issues
Closes #63
Closes #64
Closes #61

## Type of Change
- [x] feat: 새로운 기능
- [x] fix: 버그 수정
- [x] refactor: 리팩터링

## Test Plan
- [x] `npx vitest run tests/lib/auth/require-admin.test.ts` — 3 tests pass
- [x] quota 수정 Dialog: 편집 버튼 클릭 → limitValue/isActive 수정 → PUT 요청 확인
- [x] Dialog 닫고 재열기 시 이전 입력값 초기화 확인
- [x] 같은 항목 재편집 시 form 리셋 확인 (editKey 카운터)

## Checklist
- [x] 셀프 리뷰 완료
- [x] Breaking change 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)